### PR TITLE
Nytt navn, liten ktor server, infrastruktur og workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,6 @@ jobs:
           java-version: 21
           distribution: temurin
 
-
       - name: Test and build
         run: ./gradlew build
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,57 @@
+name: Build and deploy
+on:
+  push:
+    branches:
+      - main
+      - 'dev/**'
+
+concurrency:
+  group: deploy-dev
+
+env:
+  ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build_and_deploy:
+    name: Build, push and deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+
+      - name: Test and build
+        run: ./gradlew build
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test
+
+      - name: Push docker image to GAR
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: helsearbeidsgiver
+
+      - name: deploy new Unleash Apikey to dev
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/unleash-apitoken-dev.yaml
+
+      - name: Deploy to NAIS
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/dev.yaml
+          VAR: image=${{ steps.docker-build-push.outputs.image }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+name: Test
+
+on: pull_request
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Test
+        run: ./gradlew test
+        env:
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -1,0 +1,58 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+
+metadata:
+  labels:
+    team: helsearbeidsgiver
+  name: dialog
+  namespace: helsearbeidsgiver
+  annotations:
+    texas.nais.io/enabled: "true"
+spec:
+  replicas:
+    max: 1
+    min: 1
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "512Mi"
+    limits:
+      memory: "1024Mi"
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+  prometheus:
+    enabled: true
+    path: /metrics
+  secureLogs:
+    enabled: true
+  kafka:
+    pool: nav-dev
+  image: {{image}}
+  port: 8080
+  accessPolicy:
+    outbound:
+      external:
+        - host: platform.tt02.altinn.no
+        - host: helsearbeidsgiver-unleash-api.nav.cloud.nais.io
+  maskinporten:
+    enabled: true
+    scopes:
+      consumes:
+        - name: "digdir:dialogporten.serviceprovider"
+  azure:
+    application:
+      enabled: true
+  envFrom:
+    - secret: dialog-unleash-api-token
+  env:
+    - name: ALTINN_3_BASE_URL
+      value: "https://platform.tt02.altinn.no"
+    - name: ALTINN_IM_RESSURS
+      value: "nav_sykepenger_inntektsmelding-nedlasting"
+    - name: DIALOGPORTEN_SCOPE
+      value: "digdir:dialogporten.serviceprovider"
+    - name: NAV_ARBEIDSGIVER_API_BASEURL
+      value: "https://sykepenger-im-lps-api.ekstern.dev.nav.no"
+

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -30,7 +30,6 @@ spec:
   kafka:
     pool: nav-dev
   image: {{image}}
-  port: 8080
   accessPolicy:
     outbound:
       external:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -30,7 +30,6 @@ spec:
   kafka:
     pool: nav-prod
   image: {{image}}
-  port: 8080
   accessPolicy:
     outbound:
       external:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -1,0 +1,47 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+
+metadata:
+  labels:
+    team: helsearbeidsgiver
+  name: dialog
+  namespace: helsearbeidsgiver
+  annotations:
+    texas.nais.io/enabled: "true"
+spec:
+  replicas:
+    max: 1
+    min: 1
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "512Mi"
+    limits:
+      memory: "1024Mi"
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+  prometheus:
+    enabled: true
+    path: /metrics
+  secureLogs:
+    enabled: true
+  kafka:
+    pool: nav-prod
+  image: {{image}}
+  port: 8080
+  accessPolicy:
+    outbound:
+      external:
+        - host: helsearbeidsgiver-unleash-api.nav.cloud.nais.io
+  maskinporten:
+    enabled: true
+    scopes:
+      consumes:
+        - name: "digdir:dialogporten.serviceprovider"
+  azure:
+    application:
+      enabled: true
+  envFrom:
+    - secret: dialog-unleash-api-token

--- a/.nais/unleash-apitoken-dev.yaml
+++ b/.nais/unleash-apitoken-dev.yaml
@@ -1,0 +1,17 @@
+apiVersion: unleash.nais.io/v1
+kind: ApiToken
+metadata:
+  name: dialog
+  namespace: helsearbeidsgiver
+  labels:
+    team: helsearbeidsgiver
+spec:
+  unleashInstance:
+    apiVersion: unleash.nais.io/v1
+    kind: RemoteUnleash
+    name: helsearbeidsgiver
+  secretName: dialog-unleash-api-token
+
+  # Specify which environment the API token should be created for.
+  # Can be one of: development, or production.
+  environment: development

--- a/.nais/unleash-apitoken-prod.yaml
+++ b/.nais/unleash-apitoken-prod.yaml
@@ -1,0 +1,17 @@
+apiVersion: unleash.nais.io/v1
+kind: ApiToken
+metadata:
+  name: dialog
+  namespace: helsearbeidsgiver
+  labels:
+    team: helsearbeidsgiver
+spec:
+  unleashInstance:
+    apiVersion: unleash.nais.io/v1
+    kind: RemoteUnleash
+    name: helsearbeidsgiver
+  secretName: dialog-unleash-api-token
+
+  # Specify which environment the API token should be created for.
+  # Can be one of: development, or production.
+  environment: production

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hag-monologporten
+# hag-dialog
 Oppretter og oppdaterer sykepengedialoger til arbeidsgivere i Dialogporten.
 
 # Henvendelser

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,25 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("org.jmailen.kotlinter")
+    id("io.ktor.plugin") version "3.1.2"
+    application
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
+}
+
+application {
+    mainClass = "no.nav.helsearbeidsgiver.AppKt"
 }
 
 group = "no.nav.helsearbeidsgiver"
+
 version = "1.0.0"
 
 repositories {
@@ -21,7 +36,16 @@ repositories {
 }
 
 dependencies {
+    val utilsVersion: String by project
     val kotestVersion: String by project
+    val unleashVersion: String by project
+    val kafkaVersion: String by project
+
+    implementation("no.nav.helsearbeidsgiver:utils:$utilsVersion")
+    implementation("io.getunleash:unleash-client-java:$unleashVersion")
+    implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
+    implementation("io.ktor:ktor-server-core")
+    implementation("io.ktor:ktor-server-netty-jvm")
 
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
@@ -29,7 +53,4 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(21)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,10 @@ kotlin.code.style=official
 kotlinterVersion=4.4.0
 
 # Dependency versions
-kotlinVersion=2.0.21
-ktorVersion=3.1.2
+kafkaVersion=3.8.0
 kotestVersion=5.9.1
+kotlinVersion=2.0.21
 kotlinxSerializationVersion=1.8.1
+ktorVersion=3.1.2
+unleashVersion=10.2.2
+utilsVersion=0.9.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "monologporten"
+rootProject.name = "dialog"
 
 pluginManagement {
     val kotlinVersion: String by settings

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -1,0 +1,24 @@
+package no.nav.helsearbeidsgiver
+
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import no.nav.helsearbeidsgiver.kafka.startKafkaConsumer
+import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+
+fun main() {
+    startServer()
+}
+
+fun startServer() {
+    val sikkerLogger = sikkerLogger()
+
+    sikkerLogger.info("Setter opp Unleash...")
+    val unleashFeatureToggles = UnleashFeatureToggles()
+
+    embeddedServer(
+        factory = Netty,
+        port = 8080,
+        module = { startKafkaConsumer(unleashFeatureToggles) },
+    ).start(wait = true)
+}

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -16,6 +16,7 @@ fun startServer() {
     sikkerLogger.info("Setter opp Unleash...")
     val unleashFeatureToggles = UnleashFeatureToggles()
 
+    sikkerLogger.info("Starter server...")
     embeddedServer(
         factory = Netty,
         port = 8080,

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -1,0 +1,21 @@
+package no.nav.helsearbeidsgiver
+
+object Env {
+    object Unleash {
+        val apiKey = "UNLEASH_SERVER_API_TOKEN".fromEnv()
+        val apiUrl = "UNLEASH_SERVER_API_URL".fromEnv()
+        val apiEnv = "UNLEASH_SERVER_API_ENV".fromEnv()
+    }
+
+    object Kafka {
+        val topic = "KAFKA_TOPIC".fromEnv()
+        val kafkaBrokers = "KAFKA_BROKERS".fromEnv()
+        val kafkaCredstorePath = "KAFKA_CREDSTORE_PATH".fromEnv()
+        val kafkaKeystorePath = "KAFKA_KEYSTORE_PATH".fromEnv()
+        val kafkaCredstorePassword = "KAFKA_CREDSTORE_PASSWORD".fromEnv()
+    }
+
+    fun String.fromEnv(): String =
+        System.getenv(this)
+            ?: throw RuntimeException("Missing required environment variable \"$this\".")
+}

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -1,5 +1,10 @@
 package no.nav.helsearbeidsgiver
 
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.HoconApplicationConfig
+
+private val appConfig = HoconApplicationConfig(ConfigFactory.load())
+
 object Env {
     object Unleash {
         val apiKey = "UNLEASH_SERVER_API_TOKEN".fromEnv()
@@ -17,5 +22,6 @@ object Env {
 
     fun String.fromEnv(): String =
         System.getenv(this)
+            ?: appConfig.propertyOrNull(this)?.getString()
             ?: throw RuntimeException("Missing required environment variable \"$this\".")
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,5 +1,0 @@
-package no.nav.helsearbeidsgiver
-
-fun main() {
-    println("Hello World!")
-}

--- a/src/main/kotlin/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/kafka/KafkaConfig.kt
@@ -1,0 +1,63 @@
+package no.nav.helsearbeidsgiver.kafka
+
+import no.nav.helsearbeidsgiver.Env
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.util.Properties
+
+fun createKafkaConsumerConfig(): Properties {
+    val consumerKafkaProperties =
+        mapOf(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to Env.Kafka.kafkaBrokers,
+            ConsumerConfig.GROUP_ID_CONFIG to "helsearbeidsgiver-dialog",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java.name,
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to "false",
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to "1",
+            ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG to "30000",
+            ConsumerConfig.CLIENT_ID_CONFIG to "dialog",
+        )
+    return Properties().apply { putAll(consumerKafkaProperties + commonKafkaProperties()) }
+}
+
+private fun commonKafkaProperties(): Map<String, String> {
+    val pkcs12 = "PKCS12"
+    val javaKeyStore = "jks"
+
+    val truststoreConfig =
+        Env
+            .Kafka.kafkaKeystorePath
+            .let {
+                mapOf(
+                    SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG to it,
+                    CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to SecurityProtocol.SSL.name,
+                    SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG to "",
+                    SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG to javaKeyStore,
+                    SslConfigs.SSL_KEYSTORE_TYPE_CONFIG to pkcs12,
+                )
+            }
+
+    val credstoreConfig =
+        Env
+            .Kafka.kafkaCredstorePassword
+            .let {
+                mapOf(
+                    SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG to it,
+                    SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG to it,
+                    SslConfigs.SSL_KEY_PASSWORD_CONFIG to it,
+                )
+            }
+
+    val keystoreConfig =
+        Env
+            .Kafka.kafkaCredstorePath
+            .let {
+                mapOf(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG to it)
+            }
+
+    return truststoreConfig + credstoreConfig + keystoreConfig
+}

--- a/src/main/kotlin/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/kafka/KafkaConsumer.kt
@@ -15,9 +15,10 @@ fun startKafkaConsumer(unleashFeatureToggles: UnleashFeatureToggles) {
         val records = consumer.poll(Duration.ofMillis(1000))
         for (record in records) {
             sikkerLogger().info("Consumed message: ${record.value()} from partition: ${record.partition()}")
-            sikkerLogger().info("Unleash feature toggle for dialogopprettelse: ${unleashFeatureToggles.skalOppretteDialogVedMottattSykmelding()}")
+            sikkerLogger().info(
+                "Unleash feature toggle for dialogopprettelse: ${unleashFeatureToggles.skalOppretteDialogVedMottattSykmelding()}",
+            )
             consumer.commitSync()
         }
     }
 }
-

--- a/src/main/kotlin/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/kafka/KafkaConsumer.kt
@@ -1,0 +1,23 @@
+package no.nav.helsearbeidsgiver.kafka
+
+import no.nav.helsearbeidsgiver.Env
+import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import java.time.Duration
+
+fun startKafkaConsumer(unleashFeatureToggles: UnleashFeatureToggles) {
+    val consumer = KafkaConsumer<String, String>(createKafkaConsumerConfig() as Map<String, Any>)
+    val topic = Env.Kafka.topic
+    consumer.subscribe(listOf(topic))
+    val running = true
+    while (running) {
+        val records = consumer.poll(Duration.ofMillis(1000))
+        for (record in records) {
+            sikkerLogger().info("Consumed message: ${record.value()} from partition: ${record.partition()}")
+            sikkerLogger().info("Unleash feature toggle for dialogopprettelse: ${unleashFeatureToggles.skalOppretteDialogVedMottattSykmelding()}")
+            consumer.commitSync()
+        }
+    }
+}
+

--- a/src/main/kotlin/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/utils/UnleashFeatureToggles.kt
@@ -13,8 +13,8 @@ class UnleashFeatureToggles {
         DefaultUnleash(
             UnleashConfig
                 .builder()
-                .appName("sykepenger-im-lps-api")
-                .instanceId("sykepenger-im-lps-api")
+                .appName("hag-dialog")
+                .instanceId("hag-dialog")
                 .unleashAPI(apiUrl)
                 .apiKey(apiKey)
                 .environment(apiEnv)

--- a/src/main/kotlin/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/utils/UnleashFeatureToggles.kt
@@ -1,0 +1,29 @@
+package no.nav.helsearbeidsgiver.utils
+
+import io.getunleash.DefaultUnleash
+import io.getunleash.util.UnleashConfig
+import no.nav.helsearbeidsgiver.Env
+
+class UnleashFeatureToggles {
+    private val apiKey = Env.Unleash.apiKey
+    private val apiUrl = Env.Unleash.apiUrl + "/api"
+    private val apiEnv = Env.Unleash.apiEnv
+
+    private val defaultUnleash: DefaultUnleash =
+        DefaultUnleash(
+            UnleashConfig
+                .builder()
+                .appName("sykepenger-im-lps-api")
+                .instanceId("sykepenger-im-lps-api")
+                .unleashAPI(apiUrl)
+                .apiKey(apiKey)
+                .environment(apiEnv)
+                .build(),
+        )
+
+    fun skalOppretteDialogVedMottattSykmelding(): Boolean =
+        defaultUnleash.isEnabled(
+            "opprett-dialog-ved-mottatt-sykmelding",
+            false,
+        )
+}

--- a/src/main/kotlin/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/utils/UnleashFeatureToggles.kt
@@ -13,8 +13,8 @@ class UnleashFeatureToggles {
         DefaultUnleash(
             UnleashConfig
                 .builder()
-                .appName("hag-dialog")
-                .instanceId("hag-dialog")
+                .appName("dialog")
+                .instanceId("dialog")
                 .unleashAPI(apiUrl)
                 .apiKey(apiKey)
                 .environment(apiEnv)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+kafkaConsumer {
+  dialog {
+    topic = helsearbeidsgiver.dialog
+  }
+}


### PR DESCRIPTION
**Bakgrunn**
Dialog skal nå bli en ordentlig app som skal kunne deployes til dev.

**Løsning**
1. Gi nytt navn på app (`dialog` istedenfor `monologporten`).
2. Sett opp en liten ktor server med en kafkaconsumer som lytter på nytt topic (https://github.com/navikt/helsearbeidsgiver-topics/pull/44).
3. Definer nais-infrastruktur for dev og prod.
4. Sett opp Github workflows for dev (stjålet fra lps-api-appen).