### PR TITLE
Ta i bruk ny dialogportenressurs

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -54,8 +54,8 @@ spec:
   env:
     - name: ALTINN_3_BASE_URL
       value: "https://platform.tt02.altinn.no"
-    - name: ALTINN_IM_RESSURS
-      value: "nav_sykepenger_inntektsmelding-nedlasting"
+    - name: ALTINN_DIALOGPORTEN_RESSURS
+      value: "nav_sykepenger_dialogporten"
     - name: DIALOGPORTEN_SCOPE
       value: "digdir:dialogporten.serviceprovider"
     - name: NAV_ARBEIDSGIVER_API_BASEURL

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -33,7 +33,7 @@ fun startServer() {
     val dialogportenClient =
         DialogportenClient(
             baseUrl = Env.Altinn.baseUrl,
-            ressurs = Env.Altinn.imRessurs,
+            ressurs = Env.Altinn.dialogportenRessurs,
             getToken = authClient.dialogportenTokenGetter(),
         )
 

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -38,7 +38,7 @@ object Env {
 
     object Altinn {
         val baseUrl = "ALTINN_3_BASE_URL".fromEnv()
-        val imRessurs = "ALTINN_IM_RESSURS".fromEnv()
+        val imRessurs = "ALTINN_DIALOGPORTEN_RESSURS".fromEnv()
         val tokenAltinn3ExchangeEndpoint =
             "${"ALTINN_3_BASE_URL".fromEnv()}/authentication/api/v1/exchange/maskinporten"
         val dialogportenScope = "DIALOGPORTEN_SCOPE".fromEnv()

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -38,7 +38,7 @@ object Env {
 
     object Altinn {
         val baseUrl = "ALTINN_3_BASE_URL".fromEnv()
-        val imRessurs = "ALTINN_DIALOGPORTEN_RESSURS".fromEnv()
+        val dialogportenRessurs = "ALTINN_DIALOGPORTEN_RESSURS".fromEnv()
         val tokenAltinn3ExchangeEndpoint =
             "${"ALTINN_3_BASE_URL".fromEnv()}/authentication/api/v1/exchange/maskinporten"
         val dialogportenScope = "DIALOGPORTEN_SCOPE".fromEnv()


### PR DESCRIPTION
Det var ikke mulig å bruke systemressurser til å opprette dialoger i Dialogporten. Vi har derfor fått laget en egen generisk tilgangsressurs til dette formålet.