### PR TITLE
bumpet dialogporten-client versjon 2.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.code.style=official
 kotlinterVersion=4.4.0
 
 # Interne avhengigheter
-dialogportenClientVersion=2.1.1
+dialogportenClientVersion=2.1.2
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter


### PR DESCRIPTION
Bumpet dialogporten versjon. setter kunForApi til å være alltid true.