### PR TITLE
Duplikatsjekk

### DIFF
--- a/src/main/kotlin/database/DokumentkoblingRepository.kt
+++ b/src/main/kotlin/database/DokumentkoblingRepository.kt
@@ -331,4 +331,46 @@ class DokumentkoblingRepository(
                 it[InntektsmeldingTable.status] = Status.BEHANDLET
             }
         }
+
+    fun hentSykepengesoeknad(
+        soeknadId: UUID,
+        sykmeldingId: UUID,
+    ): SykepengesoeknadEntity? =
+        transaction(db) {
+            SykepengesoeknadEntity
+                .find {
+                    (SykepengesoeknadTable.id eq soeknadId) and
+                        (SykepengesoeknadTable.sykmeldingId eq sykmeldingId)
+                }.firstOrNull()
+        }
+
+    fun hentVedtaksperiodeSoeknadKobling(
+        vedtaksperiodeId: UUID,
+        soeknadId: UUID,
+    ): VedtaksperiodeSoeknadEntity? =
+        transaction(db) {
+            VedtaksperiodeSoeknadEntity
+                .find {
+                    (VedtaksperiodeSoeknadTable.vedtaksperiodeId eq vedtaksperiodeId) and
+                        (VedtaksperiodeSoeknadTable.soeknadId eq soeknadId)
+                }.firstOrNull()
+        }
+
+    fun hentForespoerselMedStatus(
+        forespoerselId: UUID,
+        forespoerselStatus: ForespoerselStatus,
+    ): ForespoerselEntity? =
+        transaction {
+            ForespoerselEntity
+                .find {
+                    (ForespoerselTable.forespoerselId eq forespoerselId) and
+                        (ForespoerselTable.forespoerselStatus eq forespoerselStatus)
+                }.firstOrNull()
+        }
+
+    fun hentInntektsmelding(inntektsmeldingId: UUID): InntektsmeldingEntity? =
+        transaction {
+            InntektsmeldingEntity
+                .findById(inntektsmeldingId)
+        }
 }

--- a/src/main/kotlin/dokumentkobling/DokumentkoblingService.kt
+++ b/src/main/kotlin/dokumentkobling/DokumentkoblingService.kt
@@ -2,6 +2,9 @@ package dokumentkobling
 
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository.ForespoerselSykmeldingKobling
+import no.nav.helsearbeidsgiver.database.ForespoerselStatus
+import no.nav.helsearbeidsgiver.kafka.Inntektsmelding
+import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
 import kotlin.collections.filter
@@ -71,4 +74,47 @@ class DokumentkoblingService(
             .filter { it.soeknadStatus == Status.BEHANDLET }
             .filtrerNyesteSykmeldingPerForespoersel()
             .firstOrNull()
+
+    fun erDuplikat(dokumentkobling: Dokumentkobling): Boolean {
+        val dokument =
+            when (dokumentkobling) {
+                is Sykmelding -> {
+                    dokumentkoblingRepository.hentSykmeldingEntitet(dokumentkobling.sykmeldingId)
+                }
+
+                is Sykepengesoeknad -> {
+                    dokumentkoblingRepository.hentSykepengesoeknad(dokumentkobling.soeknadId, dokumentkobling.sykmeldingId)
+                }
+
+                is VedtaksperiodeSoeknadKobling -> {
+                    dokumentkoblingRepository.hentVedtaksperiodeSoeknadKobling(
+                        dokumentkobling.vedtaksperiodeId,
+                        dokumentkobling.soeknadId,
+                    )
+                }
+
+                is ForespoerselSendt -> {
+                    dokumentkoblingRepository.hentForespoerselMedStatus(
+                        dokumentkobling.forespoerselId,
+                        ForespoerselStatus.SENDT,
+                    )
+                }
+
+                is ForespoerselUtgaatt -> {
+                    dokumentkoblingRepository.hentForespoerselMedStatus(
+                        dokumentkobling.forespoerselId,
+                        ForespoerselStatus.UTGAATT,
+                    )
+                }
+
+                is InntektsmeldingGodkjent -> {
+                    dokumentkoblingRepository.hentInntektsmelding(dokumentkobling.inntektsmeldingId)
+                }
+
+                is InntektsmeldingAvvist -> {
+                    dokumentkoblingRepository.hentInntektsmelding(dokumentkobling.inntektsmeldingId)
+                }
+            }
+        return dokument != null
+    }
 }

--- a/src/main/kotlin/kafka/kafka/DokumentkoblingTolker.kt
+++ b/src/main/kotlin/kafka/kafka/DokumentkoblingTolker.kt
@@ -30,6 +30,11 @@ class DokumentkoblingTolker(
                     sikkerLogger.error("Klarte ikke dekode melding. Melding blir ignorert", e)
                     return
                 }
+        if (dokumentkoblingService.erDuplikat(dekodetMelding)) {
+            logger.info("Dokumentet er duplikat. Melding blir ignorert.")
+            sikkerLogger.info("Dokumentet er duplikat. Melding blir ignorert. Melding: $melding")
+            return
+        }
 
         runCatching {
             when (dekodetMelding) {
@@ -62,6 +67,10 @@ class DokumentkoblingTolker(
                 }
             }
         }.getOrElse { e ->
+            if (e is IllegalArgumentException) {
+                logger.warn("Klarte ikke opprette/oppdatere dialog. Melding blir ignorert.", e)
+                return
+            }
             sikkerLogger.error("Klarte ikke opprette/oppdatere dialog. Avbryter.", e)
             throw e
         }

--- a/src/main/kotlin/kafka/kafka/DokumentkoblingTolker.kt
+++ b/src/main/kotlin/kafka/kafka/DokumentkoblingTolker.kt
@@ -67,10 +67,6 @@ class DokumentkoblingTolker(
                 }
             }
         }.getOrElse { e ->
-            if (e is IllegalArgumentException) {
-                logger.warn("Klarte ikke opprette/oppdatere dialog. Melding blir ignorert.", e)
-                return
-            }
             sikkerLogger.error("Klarte ikke opprette/oppdatere dialog. Avbryter.", e)
             throw e
         }

--- a/src/test/kotlin/DokumentkoblingServiceTest.kt
+++ b/src/test/kotlin/DokumentkoblingServiceTest.kt
@@ -12,8 +12,12 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository.ForespoerselSykmeldingKobling
+import no.nav.helsearbeidsgiver.database.ForespoerselEntity
 import no.nav.helsearbeidsgiver.database.ForespoerselStatus
+import no.nav.helsearbeidsgiver.database.InntektsmeldingEntity
+import no.nav.helsearbeidsgiver.database.SykepengesoeknadEntity
 import no.nav.helsearbeidsgiver.database.SykmeldingEntity
+import no.nav.helsearbeidsgiver.database.VedtaksperiodeSoeknadEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -167,5 +171,171 @@ class DokumentkoblingServiceTest :
 
             forespoerselKobling.shouldNotBeNull()
             forespoerselKobling.sykmeldingId shouldBe nySykmeldingKobling.sykmeldingId
+        }
+        test("erDuplikat returnerer false når sykmelding ikke eksisterer") {
+            val sykmelding = DokumentKoblingMockUtils.sykmelding
+            every { dokumentkoblingRepository.hentSykmeldingEntitet(sykmelding.sykmeldingId) } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(sykmelding)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når sykmelding allerede eksisterer") {
+            val sykmelding = DokumentKoblingMockUtils.sykmelding
+            val sykmeldingEntity =
+                mockk<SykmeldingEntity> {
+                    every { sykmeldingId } returns sykmelding.sykmeldingId
+                    every { data } returns sykmelding
+                }
+            every { dokumentkoblingRepository.hentSykmeldingEntitet(sykmelding.sykmeldingId) } returns sykmeldingEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(sykmelding)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når sykepengesoeknad ikke eksisterer") {
+            val soeknad = DokumentKoblingMockUtils.soeknad
+            every { dokumentkoblingRepository.hentSykepengesoeknad(soeknad.soeknadId, soeknad.sykmeldingId) } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(soeknad)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når sykepengesoeknad allerede eksisterer") {
+            val soeknad = DokumentKoblingMockUtils.soeknad
+            val soeknadEntity = mockk<SykepengesoeknadEntity>()
+            every { dokumentkoblingRepository.hentSykepengesoeknad(soeknad.soeknadId, soeknad.sykmeldingId) } returns soeknadEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(soeknad)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når vedtaksperiode-søknad kobling ikke eksisterer") {
+            val kobling = DokumentKoblingMockUtils.vedtaksperiodeSoeknadKobling
+            every {
+                dokumentkoblingRepository.hentVedtaksperiodeSoeknadKobling(
+                    kobling.vedtaksperiodeId,
+                    kobling.soeknadId,
+                )
+            } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(kobling)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når vedtaksperiode-søknad kobling allerede eksisterer") {
+            val kobling = DokumentKoblingMockUtils.vedtaksperiodeSoeknadKobling
+            val koblingEntity = mockk<VedtaksperiodeSoeknadEntity>()
+            every {
+                dokumentkoblingRepository.hentVedtaksperiodeSoeknadKobling(
+                    kobling.vedtaksperiodeId,
+                    kobling.soeknadId,
+                )
+            } returns koblingEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(kobling)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når forespørsel sendt ikke eksisterer") {
+            val forespoersel = DokumentKoblingMockUtils.forespoerselSendt
+            every {
+                dokumentkoblingRepository.hentForespoerselMedStatus(
+                    forespoersel.forespoerselId,
+                    ForespoerselStatus.SENDT,
+                )
+            } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(forespoersel)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når forespørsel sendt allerede eksisterer") {
+            val forespoersel = DokumentKoblingMockUtils.forespoerselSendt
+            val forespoerselEntity = mockk<ForespoerselEntity>()
+            every {
+                dokumentkoblingRepository.hentForespoerselMedStatus(
+                    forespoersel.forespoerselId,
+                    ForespoerselStatus.SENDT,
+                )
+            } returns forespoerselEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(forespoersel)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når forespørsel utgått ikke eksisterer") {
+            val forespoersel = DokumentKoblingMockUtils.forespoerselUtgaatt
+            every {
+                dokumentkoblingRepository.hentForespoerselMedStatus(
+                    forespoersel.forespoerselId,
+                    ForespoerselStatus.UTGAATT,
+                )
+            } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(forespoersel)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når forespørsel utgått allerede eksisterer") {
+            val forespoersel = DokumentKoblingMockUtils.forespoerselUtgaatt
+            val forespoerselEntity = mockk<ForespoerselEntity>()
+            every {
+                dokumentkoblingRepository.hentForespoerselMedStatus(
+                    forespoersel.forespoerselId,
+                    ForespoerselStatus.UTGAATT,
+                )
+            } returns forespoerselEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(forespoersel)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når inntektsmelding godkjent ikke eksisterer") {
+            val inntektsmelding = DokumentKoblingMockUtils.inntektsmeldingGodkjent
+            every { dokumentkoblingRepository.hentInntektsmelding(inntektsmelding.inntektsmeldingId) } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(inntektsmelding)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når inntektsmelding godkjent allerede eksisterer") {
+            val inntektsmelding = DokumentKoblingMockUtils.inntektsmeldingGodkjent
+            val inntektsmeldingEntity = mockk<InntektsmeldingEntity>()
+            every { dokumentkoblingRepository.hentInntektsmelding(inntektsmelding.inntektsmeldingId) } returns inntektsmeldingEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(inntektsmelding)
+
+            erDuplikat shouldBe true
+        }
+
+        test("erDuplikat returnerer false når inntektsmelding avvist ikke eksisterer") {
+            val inntektsmelding = DokumentKoblingMockUtils.inntektsmeldingAvvist
+            every { dokumentkoblingRepository.hentInntektsmelding(inntektsmelding.inntektsmeldingId) } returns null
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(inntektsmelding)
+
+            erDuplikat shouldBe false
+        }
+
+        test("erDuplikat returnerer true når inntektsmelding avvist allerede eksisterer") {
+            val inntektsmelding = DokumentKoblingMockUtils.inntektsmeldingAvvist
+            val inntektsmeldingEntity = mockk<InntektsmeldingEntity>()
+            every { dokumentkoblingRepository.hentInntektsmelding(inntektsmelding.inntektsmeldingId) } returns inntektsmeldingEntity
+
+            val erDuplikat = dokumentkoblingService.erDuplikat(inntektsmelding)
+
+            erDuplikat shouldBe true
         }
     })


### PR DESCRIPTION
Denne pull requesten legger til logikk for å oppdage og håndtere dupliserte meldinger , slik at dupliserte meldinger ignoreres og ikke behandles.

Endringene inkluderer nye repository-metoder for å hente ulike dokumenttyper, en servicemetode for å oppdage duplikater.