### PR TITLE
Legg til sykmelding pdf attachment for LPS API og PDF proxy

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -74,7 +74,7 @@ spec:
     - name: NAV_ARBEIDSGIVER_GUI_BASEURL
       value: "https://arbeidsgiver.ekstern.dev.nav.no"
     - name: NAV_DOKUMENT_PROXY_GUI_BASEURL
-      value: "https://arbeidsgiver.intern.dev.nav.no"
+      value: "https://arbeidsgiver.ekstern.dev.nav.no"
     - name: DOKUMENT_KOBLING_KAFKA_TOPIC
       value: helsearbeidsgiver.dokument-kobling
 

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -74,7 +74,7 @@ spec:
     - name: NAV_ARBEIDSGIVER_GUI_BASEURL
       value: "https://arbeidsgiver.ekstern.dev.nav.no"
     - name: NAV_DOKUMENT_PROXY_GUI_BASEURL
-      value: "https://hag-dokument-proxy.ekstern.dev.nav.no"
+      value: "https://arbeidsgiver.intern.dev.nav.no"
     - name: DOKUMENT_KOBLING_KAFKA_TOPIC
       value: helsearbeidsgiver.dokument-kobling
 

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -73,6 +73,8 @@ spec:
       value: "https://sykepenger-api.ekstern.dev.nav.no"
     - name: NAV_ARBEIDSGIVER_GUI_BASEURL
       value: "https://arbeidsgiver.ekstern.dev.nav.no"
+    - name: NAV_DOKUMENT_PROXY_GUI_BASEURL
+      value: "https://hag-dokument-proxy.ekstern.dev.nav.no"
     - name: DOKUMENT_KOBLING_KAFKA_TOPIC
       value: helsearbeidsgiver.dokument-kobling
 

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -74,5 +74,7 @@ spec:
       value: "https://sykepenger-api.nav.no"
     - name: NAV_ARBEIDSGIVER_GUI_BASEURL
       value: "https://arbeidsgiver.nav.no"
+    - name: NAV_DOKUMENT_PROXY_GUI_BASEURL
+      value: "https://arbeidsgiver.nav.no"
     - name: DOKUMENT_KOBLING_KAFKA_TOPIC
       value: helsearbeidsgiver.dokument-kobling

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -34,7 +34,7 @@ object Env {
     object Nav {
         val arbeidsgiverApiBaseUrl = "arbeidsgiver.apiBaseUrl".fromEnv()
         val arbeidsgiverGuiBaseUrl = "arbeidsgiver.guiBaseUrl".fromEnv()
-        val dokumentProxyBaseUrl = "https://dokument-proxy.ekstern.dev.nav.no"
+        val dokumentProxyBaseUrl = "arbeidsgiver.dokumentProxyBaseUrl".fromEnv()
     }
 
     object Nais {

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -34,6 +34,7 @@ object Env {
     object Nav {
         val arbeidsgiverApiBaseUrl = "arbeidsgiver.apiBaseUrl".fromEnv()
         val arbeidsgiverGuiBaseUrl = "arbeidsgiver.guiBaseUrl".fromEnv()
+        val dokumentProxyBaseUrl = "https://dokument-proxy.ekstern.dev.nav.no"
     }
 
     object Nais {

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -15,7 +15,6 @@ import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
-import java.awt.PageAttributes
 
 class SykmeldingHandler(
     private val dialogRepository: DialogRepository,

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -66,7 +66,7 @@ fun sykmeldingTransmission(sykmelding: Sykmelding): TransmissionRequest =
             ),
             createGuiAttachment(
                 displayName = "sykmelding.pdf",
-                url = "${Env.Nav.dokumentProxyBaseUrl}/hent-dokument/sykmelding/${sykmelding.sykmeldingId}.pdf",
+                url = "${Env.Nav.dokumentProxyBaseUrl}/dokument/sykmelding/${sykmelding.sykmeldingId}.pdf",
                 mediaType = "application/pdf",
             ),
         ),

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -15,6 +15,7 @@ import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
+import java.awt.PageAttributes
 
 class SykmeldingHandler(
     private val dialogRepository: DialogRepository,
@@ -61,6 +62,7 @@ fun sykmeldingTransmission(sykmelding: Sykmelding): TransmissionRequest =
             createGuiAttachment(
                 displayName = "sykmelding.pdf",
                 url = "${Env.Nav.dokumentProxyBaseUrl}/sykmelding/${sykmelding.sykmeldingId}.pdf",
+                mediaType = "application/pdf",
             ),
         ),
     )

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -65,7 +65,7 @@ fun sykmeldingTransmission(sykmelding: Sykmelding): TransmissionRequest =
                 mediaType = "application/pdf",
             ),
             createGuiAttachment(
-                displayName = "sykmelding.pdf",
+                displayName = "sykmelding",
                 url = "${Env.Nav.dokumentProxyBaseUrl}/dokument/sykmelding/${sykmelding.sykmeldingId}.pdf",
                 mediaType = "application/pdf",
             ),

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -59,9 +59,14 @@ fun sykmeldingTransmission(sykmelding: Sykmelding): TransmissionRequest =
                 displayName = "sykmelding.json",
                 url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/sykmelding/${sykmelding.sykmeldingId}",
             ),
+            createApiAttachment(
+                displayName = "sykmelding.pdf",
+                url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/sykmelding/${sykmelding.sykmeldingId}/pdf",
+                mediaType = "application/pdf",
+            ),
             createGuiAttachment(
                 displayName = "sykmelding.pdf",
-                url = "${Env.Nav.dokumentProxyBaseUrl}/sykmelding/${sykmelding.sykmeldingId}.pdf",
+                url = "${Env.Nav.dokumentProxyBaseUrl}/hent-dokument/sykmelding/${sykmelding.sykmeldingId}.pdf",
                 mediaType = "application/pdf",
             ),
         ),

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.dialogporten.SykmeldingTransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
+import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.kafka.Sykmelding
 import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
@@ -56,6 +57,10 @@ fun sykmeldingTransmission(sykmelding: Sykmelding): TransmissionRequest =
             createApiAttachment(
                 displayName = "sykmelding.json",
                 url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/sykmelding/${sykmelding.sykmeldingId}",
+            ),
+            createGuiAttachment(
+                displayName = "sykmelding.pdf",
+                url = "${Env.Nav.dokumentProxyBaseUrl}/sykmelding/${sykmelding.sykmeldingId}.pdf",
             ),
         ),
     )

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -21,6 +21,9 @@ arbeidsgiver {
 
   guiBaseUrl = "https://arbeidsgiver.ekstern.dev.nav.no"
   guiBaseUrl = ${?NAV_ARBEIDSGIVER_GUI_BASEURL}
+
+  dokumentProxyBaseUrl = "https://hag-dokument-proxy.ekstern.dev.nav.no"
+  dokumentProxyBaseUrl = ${?NAV_DOKUMENT_PROXY_BASEURL}
 }
 
 database {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -22,7 +22,7 @@ arbeidsgiver {
   guiBaseUrl = "https://arbeidsgiver.ekstern.dev.nav.no"
   guiBaseUrl = ${?NAV_ARBEIDSGIVER_GUI_BASEURL}
 
-  dokumentProxyBaseUrl = "https://hag-dokument-proxy.ekstern.dev.nav.no"
+  dokumentProxyBaseUrl = "https://arbeidsgiver.intern.dev.nav.no"
   dokumentProxyBaseUrl = ${?NAV_DOKUMENT_PROXY_BASEURL}
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -22,7 +22,7 @@ arbeidsgiver {
   guiBaseUrl = "https://arbeidsgiver.ekstern.dev.nav.no"
   guiBaseUrl = ${?NAV_ARBEIDSGIVER_GUI_BASEURL}
 
-  dokumentProxyBaseUrl = "https://arbeidsgiver.intern.dev.nav.no"
+  dokumentProxyBaseUrl = "https://arbeidsgiver.ekstern.dev.nav.no"
   dokumentProxyBaseUrl = ${?NAV_DOKUMENT_PROXY_BASEURL}
 }
 


### PR DESCRIPTION
Denne PRen legger til en dialog attachment for LPS API endepunktet for å hente en sykmelding PDF og en GUI attachment for å hente sykmelding PDF via PDF proxy for brukere på Arbeidsflaten/Dialogporten.