### PR TITLE
Implementer partisjonering av søknad oppgaver

### DIFF
--- a/src/main/kotlin/database/DokumentkoblingRepository.kt
+++ b/src/main/kotlin/database/DokumentkoblingRepository.kt
@@ -23,7 +23,6 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import java.time.LocalDateTime
 import java.util.UUID
-import kotlin.math.absoluteValue
 import kotlin.random.Random
 
 class DokumentkoblingRepository(
@@ -73,7 +72,7 @@ class DokumentkoblingRepository(
                 .map { it.data }
         }
 
-    fun henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig(): List<Sykepengesoeknad> =
+    fun henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig(): List<Sykepengesoeknad> =
         transaction(db) {
             val alleSykmeldingIder =
                 SykepengesoeknadTable
@@ -88,7 +87,7 @@ class DokumentkoblingRepository(
 
             val valgteSykmeldingIder =
                 alleSykmeldingIder.filter {
-                    it.hashCode().absoluteValue % antallPartisjoner == valgtPartisjon
+                    Math.floorMod(it.hashCode(), antallPartisjoner) == valgtPartisjon
                 }
 
             SykepengesoeknadEntity

--- a/src/main/kotlin/database/DokumentkoblingRepository.kt
+++ b/src/main/kotlin/database/DokumentkoblingRepository.kt
@@ -23,6 +23,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlin.math.absoluteValue
+import kotlin.random.Random
 
 class DokumentkoblingRepository(
     private val db: Database,
@@ -71,12 +73,29 @@ class DokumentkoblingRepository(
                 .map { it.data }
         }
 
-    fun henteSykepengeSoeknaderMedStatusMottatt(): List<Sykepengesoeknad> =
+    fun henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig(): List<Sykepengesoeknad> =
         transaction(db) {
+            val alleSykmeldingIder =
+                SykepengesoeknadTable
+                    .select(SykepengesoeknadTable.sykmeldingId)
+                    .where { SykepengesoeknadTable.status eq Status.MOTTATT }
+                    .map { it[SykepengesoeknadTable.sykmeldingId] }
+
+            if (alleSykmeldingIder.isEmpty()) return@transaction emptyList()
+
+            val antallPartisjoner = maxOf(1, alleSykmeldingIder.size / maksAntallPerHenting)
+            val valgtPartisjon = Random.nextInt(antallPartisjoner)
+
+            val valgteSykmeldingIder =
+                alleSykmeldingIder.filter {
+                    it.hashCode().absoluteValue % antallPartisjoner == valgtPartisjon
+                }
+
             SykepengesoeknadEntity
-                .find { SykepengesoeknadTable.status eq Status.MOTTATT }
-                .orderBy(SykepengesoeknadTable.opprettet to SortOrder.ASC)
-                .limit(maksAntallPerHenting)
+                .find {
+                    (SykepengesoeknadTable.status eq Status.MOTTATT) and
+                        (SykepengesoeknadTable.sykmeldingId inList valgteSykmeldingIder)
+                }.orderBy(SykepengesoeknadTable.opprettet to SortOrder.ASC)
                 .map {
                     Sykepengesoeknad(
                         soeknadId = it.id.value,

--- a/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
+++ b/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
@@ -21,7 +21,7 @@ class SykepengeSoeknadJobb(
             return
         }
 
-        val soeknader = dokumentkoblingRepository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+        val soeknader = dokumentkoblingRepository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
 
         oppdaterMetrikkForAntallSykepengesoeknaderMedStatusMottatt(nyVerdi = soeknader.size)
             .also { logger.info("Fant ${soeknader.size} sykepengesøknader med status MOTTATT klar til behandling.") }

--- a/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
+++ b/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
@@ -20,7 +20,8 @@ class SykepengeSoeknadJobb(
             logger.warn("Oppretter ikke dialoger for sykepengesøknader da det er deaktivert i Unleash.")
             return
         }
-        val soeknader = dokumentkoblingRepository.henteSykepengeSoeknaderMedStatusMottatt()
+
+        val soeknader = dokumentkoblingRepository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
 
         oppdaterMetrikkForAntallSykepengesoeknaderMedStatusMottatt(nyVerdi = soeknader.size)
             .also { logger.info("Fant ${soeknader.size} sykepengesøknader med status MOTTATT klar til behandling.") }

--- a/src/test/kotlin/DokumentkoblingTest.kt
+++ b/src/test/kotlin/DokumentkoblingTest.kt
@@ -75,7 +75,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(soeknad)
                 repository.opprettSykepengesoeknad(soeknad.copy(soeknadId = soeknadId2))
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                 hentet.size shouldBe 2
                 hentet[0].soeknadId shouldBe soeknad.soeknadId
                 hentet[1].soeknadId shouldBe soeknadId2
@@ -100,7 +100,10 @@ class DokumentkoblingTest :
             test("hente mottatte søknader partisjonert tilfeldig dekker alle elementer") {
                 val soeknader =
                     List(maksAntallPerHenting * 3) {
-                        DokumentKoblingMockUtils.soeknad.copy(soeknadId = UUID.randomUUID())
+                        DokumentKoblingMockUtils.soeknad.copy(
+                            soeknadId = UUID.randomUUID(),
+                            sykmeldingId = UUID.randomUUID(),
+                        )
                     }
 
                 soeknader.forEach { repository.opprettSykepengesoeknad(it) }
@@ -108,7 +111,7 @@ class DokumentkoblingTest :
                 val hentetSoeknadIder =
                     (1..17)
                         .flatMap {
-                            repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                            repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                         }.map { it.soeknadId }
                         .toSet()
 
@@ -123,7 +126,7 @@ class DokumentkoblingTest :
 
                 soeknader.forEach { repository.opprettSykepengesoeknad(it) }
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                 val forventetSekvens = soeknader.map { it.soeknadId }
                 val partisjonIForventetSekvens = hentet.map { it.soeknadId }.sortedBy { forventetSekvens.indexOf(it) }
 
@@ -194,7 +197,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(soeknad.copy(soeknadId = soeknadId2))
                 repository.settSykepengeSoeknadJobbTilBehandlet(soeknad.soeknadId)
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                 hentet.size shouldBe 1
                 hentet[0].soeknadId shouldBe soeknadId2
             }
@@ -234,7 +237,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(nySoeknad)
 
                 // Sjekk at begge søknadene er mottatt før vi setter til tidsavbrutt
-                val mottatteSoeknaderFoer = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val mottatteSoeknaderFoer = repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                 mottatteSoeknaderFoer shouldBe listOf(gammelSoeknad, nySoeknad)
 
                 // Sett søknader til tidsavbrutt før grensen
@@ -243,7 +246,7 @@ class DokumentkoblingTest :
 
                 // Sjekk at kun den gamle søknaden er satt til tidsavbrutt
                 antallOppdatert shouldBe 1
-                val mottatteSoeknaderEtter = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val mottatteSoeknaderEtter = repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig()
                 mottatteSoeknaderEtter shouldBe listOf(nySoeknad)
 
                 // Sjekk at den gamle søknaden faktisk har status TIDSAVBRUTT

--- a/src/test/kotlin/DokumentkoblingTest.kt
+++ b/src/test/kotlin/DokumentkoblingTest.kt
@@ -2,6 +2,7 @@ import dokumentkobling.InnsendingType
 import dokumentkobling.Status
 import dokumentkobling.VedtaksperiodeSoeknadKobling
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.collections.shouldNotContain
@@ -74,7 +75,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(soeknad)
                 repository.opprettSykepengesoeknad(soeknad.copy(soeknadId = soeknadId2))
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMottatt()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
                 hentet.size shouldBe 2
                 hentet[0].soeknadId shouldBe soeknad.soeknadId
                 hentet[1].soeknadId shouldBe soeknadId2
@@ -96,7 +97,25 @@ class DokumentkoblingTest :
                 }
             }
 
-            test("henter kun de maksAntallPerHenting eldste søknadene med mottatt status") {
+            test("hente mottatte søknader partisjonert tilfeldig dekker alle elementer") {
+                val soeknader =
+                    List(maksAntallPerHenting * 3) {
+                        DokumentKoblingMockUtils.soeknad.copy(soeknadId = UUID.randomUUID())
+                    }
+
+                soeknader.forEach { repository.opprettSykepengesoeknad(it) }
+
+                val hentetSoeknadIder =
+                    (1..17)
+                        .flatMap {
+                            repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                        }.map { it.soeknadId }
+                        .toSet()
+
+                hentetSoeknadIder shouldContainAll soeknader.map { it.soeknadId }
+            }
+
+            test("hente mottatte søknader partisjonert tilfeldig er sortert stigende") {
                 val soeknader =
                     List(maksAntallPerHenting + 1) {
                         DokumentKoblingMockUtils.soeknad.copy(soeknadId = UUID.randomUUID())
@@ -104,12 +123,11 @@ class DokumentkoblingTest :
 
                 soeknader.forEach { repository.opprettSykepengesoeknad(it) }
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMottatt()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
+                val forventetSekvens = soeknader.map { it.soeknadId }
+                val partisjonIForventetSekvens = hentet.map { it.soeknadId }.sortedBy { forventetSekvens.indexOf(it) }
 
-                assertSoftly(hentet) {
-                    size shouldBe maksAntallPerHenting
-                    map { it.soeknadId }.shouldNotContain(soeknader.last().soeknadId)
-                }
+                hentet.map { it.soeknadId } shouldBe partisjonIForventetSekvens
             }
 
             test("henter kun de maksAntallPerHenting eldste forespørsel-sykmelding-koblingene") {
@@ -176,7 +194,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(soeknad.copy(soeknadId = soeknadId2))
                 repository.settSykepengeSoeknadJobbTilBehandlet(soeknad.soeknadId)
 
-                val hentet = repository.henteSykepengeSoeknaderMedStatusMottatt()
+                val hentet = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
                 hentet.size shouldBe 1
                 hentet[0].soeknadId shouldBe soeknadId2
             }
@@ -216,7 +234,7 @@ class DokumentkoblingTest :
                 repository.opprettSykepengesoeknad(nySoeknad)
 
                 // Sjekk at begge søknadene er mottatt før vi setter til tidsavbrutt
-                val mottatteSoeknaderFoer = repository.henteSykepengeSoeknaderMedStatusMottatt()
+                val mottatteSoeknaderFoer = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
                 mottatteSoeknaderFoer shouldBe listOf(gammelSoeknad, nySoeknad)
 
                 // Sett søknader til tidsavbrutt før grensen
@@ -225,7 +243,7 @@ class DokumentkoblingTest :
 
                 // Sjekk at kun den gamle søknaden er satt til tidsavbrutt
                 antallOppdatert shouldBe 1
-                val mottatteSoeknaderEtter = repository.henteSykepengeSoeknaderMedStatusMottatt()
+                val mottatteSoeknaderEtter = repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig()
                 mottatteSoeknaderEtter shouldBe listOf(nySoeknad)
 
                 // Sjekk at den gamle søknaden faktisk har status TIDSAVBRUTT

--- a/src/test/kotlin/SykepengeSoeknadJobbTest.kt
+++ b/src/test/kotlin/SykepengeSoeknadJobbTest.kt
@@ -41,7 +41,8 @@ class SykepengeSoeknadJobbTest :
         beforeTest {
             clearAllMocks()
             every { repository.settSykepengeSoeknadJobbTilBehandlet(any()) } just runs
-            every { repository.henteSykepengeSoeknaderMedStatusMottatt() } returns listOf(DokumentKoblingMockUtils.soeknad)
+            every { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() } returns
+                listOf(DokumentKoblingMockUtils.soeknad)
             every { repository.hentSykmeldingEntitet(sykmeldingId) } returns sykmeldingEntity
             every { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
         }
@@ -52,7 +53,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottatt() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
             verify(exactly = 1) { dialogportenService.oppdaterDialogMedSykepengesoeknad(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -63,7 +64,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottatt() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
             verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -74,7 +75,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottatt() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
             verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -85,14 +86,14 @@ class SykepengeSoeknadJobbTest :
 
             val exceptionSoeknad = DokumentKoblingMockUtils.soeknad.copy(soeknadId = UUID.randomUUID())
 
-            every { repository.henteSykepengeSoeknaderMedStatusMottatt() } returns
+            every { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() } returns
                 listOf(exceptionSoeknad, DokumentKoblingMockUtils.soeknad)
             every { dialogportenService.opprettTransmissionForSoeknad(exceptionSoeknad) } throws
                 NotFoundException("Fant ikke sykmelding for søknad")
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottatt() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
             verify(exactly = 2) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }

--- a/src/test/kotlin/SykepengeSoeknadJobbTest.kt
+++ b/src/test/kotlin/SykepengeSoeknadJobbTest.kt
@@ -41,7 +41,7 @@ class SykepengeSoeknadJobbTest :
         beforeTest {
             clearAllMocks()
             every { repository.settSykepengeSoeknadJobbTilBehandlet(any()) } just runs
-            every { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() } returns
+            every { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() } returns
                 listOf(DokumentKoblingMockUtils.soeknad)
             every { repository.hentSykmeldingEntitet(sykmeldingId) } returns sykmeldingEntity
             every { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
@@ -53,7 +53,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
             verify(exactly = 1) { dialogportenService.oppdaterDialogMedSykepengesoeknad(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -64,7 +64,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
             verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -75,7 +75,7 @@ class SykepengeSoeknadJobbTest :
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
             verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
@@ -86,14 +86,14 @@ class SykepengeSoeknadJobbTest :
 
             val exceptionSoeknad = DokumentKoblingMockUtils.soeknad.copy(soeknadId = UUID.randomUUID())
 
-            every { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() } returns
+            every { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() } returns
                 listOf(exceptionSoeknad, DokumentKoblingMockUtils.soeknad)
             every { dialogportenService.opprettTransmissionForSoeknad(exceptionSoeknad) } throws
                 NotFoundException("Fant ikke sykmelding for søknad")
 
             sykepengeSoeknadJobb.doJob()
 
-            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMotattPartionertTilfeldig() }
+            verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
             verify(exactly = 2) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }


### PR DESCRIPTION
**Bakgrunn:**
Vi mottar en liste av oppgaver.
Om en tjeneste går ned venter vi automatisk til nødvendig informasjon før oppgaven gjennomføres.

**Problem:**
Dagens system kan får propp ved mange uløste oppgaver.
Systemet prøver å løse gamle oppgaver som ikke har nødvendig informasjon for å løses.
Som fører til at nye oppgaver som muligens kan løses blir ignorert. 

**Løsning:**
Partisjoner oppgavene og velg en tilfeldig partisjon.
Men denne metoden blir alle oppgaver til slutt gjennomført.

Partisjonerer på sykmelding UUID slik at 2 søknader på samme sykmelding blir gjennomført i riktig rekkefølge