### PR TITLE
Legg til attatchment for søknad PDF

### DIFF
--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -67,7 +67,7 @@ fun sykepengesoknadTransmission(sykepengesoeknad: Sykepengesoeknad): Transmissio
             ),
             createGuiAttachment(
                 displayName = "sykepengesoeknad",
-                url = "${Env.Nav.dokumentProxyBaseUrl}/dokument/soknad/${sykepengesoeknad.soeknadId}.pdf",
+                url = "${Env.Nav.dokumentProxyBaseUrl}/dokument/sykepengesoeknad/${sykepengesoeknad.soeknadId}.pdf",
                 mediaType = "application/pdf",
             ),
         ),

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.dialogporten.LpsApiExtendedType
 import no.nav.helsearbeidsgiver.dialogporten.SykepengesoknadTransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
+import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
 import no.nav.helsearbeidsgiver.kafka.Sykepengesoeknad
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -58,6 +59,16 @@ fun sykepengesoknadTransmission(sykepengesoeknad: Sykepengesoeknad): Transmissio
             createApiAttachment(
                 "sykepengesoeknad.json",
                 "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/sykepengesoeknad/${sykepengesoeknad.soeknadId}",
+            ),
+            createApiAttachment(
+                displayName = "sykepengesoeknad.pdf",
+                url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/sykepengesoeknad/${sykepengesoeknad.soeknadId}/pdf",
+                mediaType = "application/pdf",
+            ),
+            createGuiAttachment(
+                displayName = "sykepengesoeknad",
+                url = "${Env.Nav.dokumentProxyBaseUrl}/dokument/soknad/${sykepengesoeknad.soeknadId}.pdf",
+                mediaType = "application/pdf",
             ),
         ),
     )


### PR DESCRIPTION
**Problem:**
Det er ingen referanse til søknad PDF i dialogen

**Løsning:**
Legger til lenke til søknad PDF via LPS API og for GUI via dokument proxy -> LPS API (tokenX)

**Testet i dev:**
<img width="445"  alt="image" src="https://github.com/user-attachments/assets/f1042bca-20d3-4002-a18f-ae0eab09ce0d" />


