### PR TITLE
Ny Fritak-AGP ressurs med andre små endringer

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -65,8 +65,10 @@ spec:
   env:
     - name: ALTINN_3_BASE_URL
       value: "https://platform.tt02.altinn.no"
-    - name: ALTINN_DIALOGPORTEN_RESSURS
+    - name: SYKEPENGER_DIALOGPORTEN_RESSURS
       value: "nav_sykepenger_dialog"
+    - name: FRITAK_AGP_DIALOGPORTEN_RESSURS
+      value: "nav_sykepenger_fritak-arbeidsgiverperiode"
     - name: DIALOGPORTEN_SCOPE
       value: "digdir:dialogporten.serviceprovider"
     - name: NAV_ARBEIDSGIVER_API_BASEURL

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -68,6 +68,10 @@ spec:
       value: "https://platform.altinn.no"
     - name: ALTINN_DIALOGPORTEN_RESSURS
       value: "nav_sykepenger_dialog"
+    - name: SYKEPENGER_DIALOGPORTEN_RESSURS
+      value: "nav_sykepenger_dialog"
+    - name: FRITAK_AGP_DIALOGPORTEN_RESSURS
+      value: "nav_sykepenger_fritak-arbeidsgiverperiode"
     - name: DIALOGPORTEN_SCOPE
       value: "digdir:dialogporten.serviceprovider"
     - name: NAV_ARBEIDSGIVER_API_BASEURL

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -66,8 +66,6 @@ spec:
   env:
     - name: ALTINN_3_BASE_URL
       value: "https://platform.altinn.no"
-    - name: ALTINN_DIALOGPORTEN_RESSURS
-      value: "nav_sykepenger_dialog"
     - name: SYKEPENGER_DIALOGPORTEN_RESSURS
       value: "nav_sykepenger_dialog"
     - name: FRITAK_AGP_DIALOGPORTEN_RESSURS

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -15,6 +15,7 @@ import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytForespoerselJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytInntektsmeldingJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytSykepengeSoeknadJobb
@@ -47,13 +48,18 @@ fun startServer() {
     val authClient = AuthClient()
 
     logger.info("Setter opp DialogportenClient...")
-    val dialogportenClient =
+    val sykePengerdialogportenClient =
         DialogportenClient(
             baseUrl = Env.Altinn.baseUrl,
             ressurs = Env.Altinn.dialogportenRessurs,
             getToken = authClient.dialogportenTokenGetter(),
         )
-
+    val fritakDialogportenClient =
+        DialogportenClient(
+            baseUrl = Env.Altinn.baseUrl,
+            ressurs = Env.Altinn.fritakDialogportenRessurs,
+            getToken = authClient.dialogportenTokenGetter(),
+        )
     logger.info("Setter opp DialogRepository...")
     val dialogRepository = DialogRepository(database.db)
     val fritakDialogRepository =
@@ -64,11 +70,14 @@ fun startServer() {
     val dialogportenService =
         DialogportenService(
             dialogRepository = dialogRepository,
-            dialogportenClient = dialogportenClient,
+            dialogportenClient = sykePengerdialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
-            fritakDialogRepository = fritakDialogRepository,
         )
-
+    val fritakDialogportenService =
+        FritakDialogportenService(
+            fritakDialogRepository = fritakDialogRepository,
+            dialogportenClient = fritakDialogportenClient,
+        )
     val jobber =
         listOf(
             SykmeldingJobb(
@@ -114,7 +123,7 @@ fun startServer() {
                 naisRoutes(HelsesjekkService(database.db))
                 metrikkRoutes()
             }
-            configureKafkaConsumer(unleashFeatureToggles, dokumentKoblingService, dialogportenService)
+            configureKafkaConsumer(unleashFeatureToggles, dokumentKoblingService, fritakDialogportenService)
             startRecurringJobs(jobber)
             monitor.subscribe(ApplicationStopPreparing) {
                 logger.info("Applikasjonen stopper, avslutter eventuelle jobber...")

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -51,7 +51,7 @@ fun startServer() {
     val sykePengerdialogportenClient =
         DialogportenClient(
             baseUrl = Env.Altinn.baseUrl,
-            ressurs = Env.Altinn.dialogportenRessurs,
+            ressurs = Env.Altinn.sykepengerDialogportenRessurs,
             getToken = authClient.dialogportenTokenGetter(),
         )
     val fritakDialogportenClient =

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -14,8 +14,8 @@ import no.nav.helsearbeidsgiver.database.Database
 import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytForespoerselJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytInntektsmeldingJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytSykepengeSoeknadJobb
@@ -67,8 +67,8 @@ fun startServer() {
             .FritakDialogRepository(database.db)
     val dokumentkoblingRepository = DokumentkoblingRepository(db = database.db, maksAntallPerHenting = 5000)
     val dokumentKoblingService = DokumentkoblingService(dokumentkoblingRepository)
-    val dialogportenService =
-        DialogportenService(
+    val sykepengerDialogportenService =
+        SykepengerDialogportenService(
             dialogRepository = dialogRepository,
             dialogportenClient = sykePengerdialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
@@ -82,22 +82,22 @@ fun startServer() {
         listOf(
             SykmeldingJobb(
                 dokumentkoblingRepository = dokumentkoblingRepository,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             ),
             SykepengeSoeknadJobb(
                 dokumentkoblingRepository = dokumentkoblingRepository,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             ),
             ForespoerselJobb(
                 dokumentkoblingService = dokumentKoblingService,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             ),
             InntektsmeldingJobb(
                 dokumentkoblingService = dokumentKoblingService,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             ),
             AvbrytSykmeldingJobb(

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -44,7 +44,7 @@ object Env {
 
     object Altinn {
         val baseUrl = "ALTINN_3_BASE_URL".fromEnv()
-        val dialogportenRessurs = "SYKEPENGER_DIALOGPORTEN_RESSURS".fromEnv()
+        val sykepengerDialogportenRessurs = "SYKEPENGER_DIALOGPORTEN_RESSURS".fromEnv()
         val fritakDialogportenRessurs = "FRITAK_AGP_DIALOGPORTEN_RESSURS".fromEnv()
         val tokenAltinn3ExchangeEndpoint =
             "${"ALTINN_3_BASE_URL".fromEnv()}/authentication/api/v1/exchange/maskinporten"

--- a/src/main/kotlin/Env.kt
+++ b/src/main/kotlin/Env.kt
@@ -44,7 +44,8 @@ object Env {
 
     object Altinn {
         val baseUrl = "ALTINN_3_BASE_URL".fromEnv()
-        val dialogportenRessurs = "ALTINN_DIALOGPORTEN_RESSURS".fromEnv()
+        val dialogportenRessurs = "SYKEPENGER_DIALOGPORTEN_RESSURS".fromEnv()
+        val fritakDialogportenRessurs = "FRITAK_AGP_DIALOGPORTEN_RESSURS".fromEnv()
         val tokenAltinn3ExchangeEndpoint =
             "${"ALTINN_3_BASE_URL".fromEnv()}/authentication/api/v1/exchange/maskinporten"
         val dialogportenScope = "DIALOGPORTEN_SCOPE".fromEnv()

--- a/src/main/kotlin/dialogporten/DialogportenService.kt
+++ b/src/main/kotlin/dialogporten/DialogportenService.kt
@@ -24,22 +24,12 @@ class DialogportenService(
     dialogRepository: DialogRepository,
     dialogportenClient: DialogportenClient,
     unleashFeatureToggles: UnleashFeatureToggles,
-    fritakDialogRepository: FritakDialogRepository,
 ) {
     private val sykmeldingHandler = SykmeldingHandler(dialogRepository, dialogportenClient, unleashFeatureToggles)
     private val sykepengesoeknadHandler = SykepengesoeknadHandler(dialogRepository, dialogportenClient)
     private val forespoerselHandler = ForespoerselHandler(dialogRepository, dialogportenClient)
     private val inntektsmeldingHandler = InntektsmeldingHandler(dialogRepository, dialogportenClient)
     private val utgaattForespoerselHandler = UtgaattForespoerselHandler(dialogRepository, dialogportenClient)
-    private val fritakAgpSoeknadHandler = FritakAgpSoeknadHandler(dialogportenClient, fritakDialogRepository)
-    private val fritakAgpKravHandler = FritakAgpKravHandler(dialogportenClient, fritakDialogRepository)
-
-    suspend fun opprettDialogForFritakAgp(dialogMelding: DialogMelding) {
-        when (dialogMelding) {
-            is FritakKravMelding -> fritakAgpKravHandler.behandleKravDialog(dialogMelding)
-            is FritakSoeknadMelding -> fritakAgpSoeknadHandler.behandleSoeknadDialog(dialogMelding)
-        }
-    }
 
     fun opprettOgLagreDialog(sykmelding: Sykmelding) {
         sykmeldingHandler.opprettOgLagreDialog(sykmelding)

--- a/src/main/kotlin/dialogporten/FritakDialogportenService.kt
+++ b/src/main/kotlin/dialogporten/FritakDialogportenService.kt
@@ -1,0 +1,23 @@
+package no.nav.helsearbeidsgiver.dialogporten
+
+import dialogporten.handlers.FritakAgpKravHandler
+import no.nav.helsearbeidsgiver.database.FritakDialogRepository
+import no.nav.helsearbeidsgiver.dialogporten.handlers.FritakAgpSoeknadHandler
+import no.nav.helsearbeidsgiver.kafka.DialogMelding
+import no.nav.helsearbeidsgiver.kafka.FritakKravMelding
+import no.nav.helsearbeidsgiver.kafka.FritakSoeknadMelding
+
+class FritakDialogportenService(
+    fritakDialogRepository: FritakDialogRepository,
+    dialogportenClient: DialogportenClient,
+) {
+    private val fritakAgpSoeknadHandler = FritakAgpSoeknadHandler(dialogportenClient, fritakDialogRepository)
+    private val fritakAgpKravHandler = FritakAgpKravHandler(dialogportenClient, fritakDialogRepository)
+
+    suspend fun opprettDialogForFritakAgp(dialogMelding: DialogMelding) {
+        when (dialogMelding) {
+            is FritakKravMelding -> fritakAgpKravHandler.behandleKravDialog(dialogMelding)
+            is FritakSoeknadMelding -> fritakAgpSoeknadHandler.behandleSoeknadDialog(dialogMelding)
+        }
+    }
+}

--- a/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
+++ b/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
@@ -146,8 +146,8 @@ fun FritakKravMelding.toTittel(): String =
     when (this) {
         is GravidKravOpprettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er opprettet"
         is GravidKravEndret -> "Krav om fritak for arbeidsgiverperiode ved graviditet er endret"
-        is GravidKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er slettet"
+        is GravidKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er annulert"
         is KroniskKravOpprettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er opprettet"
         is KroniskKravEndret -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er endret"
-        is KroniskKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er slettet"
+        is KroniskKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er annulert"
     }

--- a/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
+++ b/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
@@ -146,8 +146,8 @@ fun FritakKravMelding.toTittel(): String =
     when (this) {
         is GravidKravOpprettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er opprettet"
         is GravidKravEndret -> "Krav om fritak for arbeidsgiverperiode ved graviditet er endret"
-        is GravidKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er annulert"
+        is GravidKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved graviditet er annullert"
         is KroniskKravOpprettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er opprettet"
         is KroniskKravEndret -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er endret"
-        is KroniskKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er annulert"
+        is KroniskKravSlettet -> "Krav om fritak for arbeidsgiverperiode ved kronisk sykdom er annullert"
     }

--- a/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
+++ b/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
@@ -1,17 +1,11 @@
 package no.nav.helsearbeidsgiver.dialogporten
 
-import dialogporten.handlers.FritakAgpKravHandler
 import no.nav.helsearbeidsgiver.database.DialogRepository
-import no.nav.helsearbeidsgiver.database.FritakDialogRepository
 import no.nav.helsearbeidsgiver.dialogporten.handlers.ForespoerselHandler
-import no.nav.helsearbeidsgiver.dialogporten.handlers.FritakAgpSoeknadHandler
 import no.nav.helsearbeidsgiver.dialogporten.handlers.InntektsmeldingHandler
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykepengesoeknadHandler
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykmeldingHandler
 import no.nav.helsearbeidsgiver.dialogporten.handlers.UtgaattForespoerselHandler
-import no.nav.helsearbeidsgiver.kafka.DialogMelding
-import no.nav.helsearbeidsgiver.kafka.FritakKravMelding
-import no.nav.helsearbeidsgiver.kafka.FritakSoeknadMelding
 import no.nav.helsearbeidsgiver.kafka.Inntektsmelding
 import no.nav.helsearbeidsgiver.kafka.Inntektsmeldingsforespoersel
 import no.nav.helsearbeidsgiver.kafka.Sykepengesoeknad
@@ -20,7 +14,7 @@ import no.nav.helsearbeidsgiver.kafka.UtgaattInntektsmeldingForespoersel
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import java.util.UUID
 
-class DialogportenService(
+class SykepengerDialogportenService(
     dialogRepository: DialogRepository,
     dialogportenClient: DialogportenClient,
     unleashFeatureToggles: UnleashFeatureToggles,

--- a/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
@@ -24,6 +24,8 @@ import no.nav.helsearbeidsgiver.kafka.KroniskKravSlettet
 import no.nav.helsearbeidsgiver.kafka.foedselsdatoFraFnr
 import no.nav.helsearbeidsgiver.utils.log.logger
 
+private const val ENDRE_KRAV_ACTION_KNAPP = "Endre / Annuller krav"
+
 class FritakAgpKravHandler(
     val dialogportenClient: DialogportenClient,
     val fritakDialogRepository: FritakDialogRepository,
@@ -82,10 +84,10 @@ class FritakAgpKravHandler(
             dialogId = dialogId,
             guiAction =
                 GuiAction(
-                    name = "Endre krav",
+                    name = ENDRE_KRAV_ACTION_KNAPP,
                     url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/kronisk/krav/${kroniskKrav.id}",
                     action = Action.READ.value,
-                    title = listOf(ContentValueItem("Endre krav")),
+                    title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
                     priority = GuiAction.Priority.Primary,
                 ),
         )
@@ -132,10 +134,10 @@ class FritakAgpKravHandler(
                 guiActions =
                     listOf(
                         GuiAction(
-                            name = "Endre krav",
+                            name = ENDRE_KRAV_ACTION_KNAPP,
                             url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/kronisk/krav/${kroniskKravEndret.id}",
                             action = Action.READ.value,
-                            title = listOf(ContentValueItem("Endre krav")),
+                            title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
                             priority = GuiAction.Priority.Primary,
                         ),
                     ),
@@ -200,10 +202,10 @@ class FritakAgpKravHandler(
             dialogId = dialogId,
             guiAction =
                 GuiAction(
-                    name = "Endre krav",
+                    name = ENDRE_KRAV_ACTION_KNAPP,
                     url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/gravid/krav/${gravidKrav.id}",
                     action = Action.READ.value,
-                    title = listOf(ContentValueItem("Endre krav")),
+                    title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
                     priority = GuiAction.Priority.Primary,
                 ),
         )
@@ -251,10 +253,10 @@ class FritakAgpKravHandler(
                 guiActions =
                     listOf(
                         GuiAction(
-                            name = "Endre krav",
+                            name = "Endre / Annuller krav",
                             url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/gravid/krav/${gravidKravEndret.id}",
                             action = Action.READ.value,
-                            title = listOf(ContentValueItem("Endre krav")),
+                            title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
                             priority = GuiAction.Priority.Primary,
                         ),
                     ),

--- a/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
@@ -257,7 +257,7 @@ class FritakAgpKravHandler(
                 guiActions =
                     listOf(
                         GuiAction(
-                            name = "Endre / Annuller krav",
+                            name = ENDRE_KRAV_ACTION_KNAPP,
                             url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/gravid/krav/${gravidKravEndret.id}",
                             action = Action.READ.value,
                             title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),

--- a/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/FritakAgpKravHandler.kt
@@ -80,17 +80,19 @@ class FritakAgpKravHandler(
                 ).toTransmission(),
             )
 
-        dialogportenClient.addGuiAction(
-            dialogId = dialogId,
-            guiAction =
-                GuiAction(
-                    name = ENDRE_KRAV_ACTION_KNAPP,
-                    url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/kronisk/krav/${kroniskKrav.id}",
-                    action = Action.READ.value,
-                    title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
-                    priority = GuiAction.Priority.Primary,
-                ),
-        )
+        if (kroniskKrav !is KroniskKravSlettet) {
+            dialogportenClient.addGuiAction(
+                dialogId = dialogId,
+                guiAction =
+                    GuiAction(
+                        name = ENDRE_KRAV_ACTION_KNAPP,
+                        url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/kronisk/krav/${kroniskKrav.id}",
+                        action = Action.READ.value,
+                        title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
+                        priority = GuiAction.Priority.Primary,
+                    ),
+            )
+        }
 
         fritakDialogRepository.lagreKravDialog(
             dialogId = dialogId,
@@ -198,17 +200,19 @@ class FritakAgpKravHandler(
                 ).toTransmission(),
             )
 
-        dialogportenClient.addGuiAction(
-            dialogId = dialogId,
-            guiAction =
-                GuiAction(
-                    name = ENDRE_KRAV_ACTION_KNAPP,
-                    url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/gravid/krav/${gravidKrav.id}",
-                    action = Action.READ.value,
-                    title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
-                    priority = GuiAction.Priority.Primary,
-                ),
-        )
+        if (gravidKrav !is GravidKravSlettet) {
+            dialogportenClient.addGuiAction(
+                dialogId = dialogId,
+                guiAction =
+                    GuiAction(
+                        name = ENDRE_KRAV_ACTION_KNAPP,
+                        url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/fritak-agp/nb/gravid/krav/${gravidKrav.id}",
+                        action = Action.READ.value,
+                        title = listOf(ContentValueItem(ENDRE_KRAV_ACTION_KNAPP)),
+                        priority = GuiAction.Priority.Primary,
+                    ),
+            )
+        }
 
         fritakDialogRepository.lagreKravDialog(
             dialogId = dialogId,
@@ -304,9 +308,10 @@ class FritakAgpKravHandler(
                 orgnr = kravmelding.orgnr.verdi,
             )
         } else {
-            logger().warn(
-                "Klarte ikke å finne opprinnelig krav for kronisk krav slettet med id ${kravmelding.id}. Ingen dialog å oppdatere.",
+            logger().info(
+                "Klarte ikke å finne opprinnelig krav for kronisk krav slettet med id ${kravmelding.id}. Oppretter ny dialog.",
             )
+            opprettDialogForKroniskKrav(kravmelding)
         }
     }
 
@@ -336,9 +341,10 @@ class FritakAgpKravHandler(
                 orgnr = gravidKravSlettet.orgnr.verdi,
             )
         } else {
-            logger().warn(
-                "Klarte ikke å finne opprinnelig krav for gravid krav slettet med id ${gravidKravSlettet.id}. Ingen dialog å oppdatere.",
+            logger().info(
+                "Klarte ikke å finne opprinnelig krav for gravid krav slettet med id ${gravidKravSlettet.id}. oppretter ny dialog.",
             )
+            opprettDialogForGravidKrav(gravidKravSlettet)
         }
     }
 }

--- a/src/main/kotlin/dokumentkobling/ForespoerselJobb.kt
+++ b/src/main/kotlin/dokumentkobling/ForespoerselJobb.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import no.nav.hag.utils.bakgrunnsjobb.RecurringJob
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.ForespoerselStatus
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.metrikk.oppdaterMetrikkForAntallForespoerslerMedStatusMottatt
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -14,7 +14,7 @@ import java.time.Duration
 
 class ForespoerselJobb(
     private val dokumentkoblingService: DokumentkoblingService,
-    private val dialogportenService: DialogportenService,
+    private val sykepengerDialogportenService: SykepengerDialogportenService,
     private val unleashFeatureToggles: UnleashFeatureToggles,
 ) : RecurringJob(CoroutineScope(Dispatchers.IO), Duration.ofSeconds(30).toMillis()) {
     override fun doJob() {
@@ -32,7 +32,7 @@ class ForespoerselJobb(
             .forEach { (vedtaksperiodeId, forespoersler) ->
                 try {
                     forespoersler.forEach { forespoersel ->
-                        dialogportenService.opprettTransmissionForForespoersel(forespoersel)
+                        sykepengerDialogportenService.opprettTransmissionForForespoersel(forespoersel)
                         dokumentkoblingService.settForespoerselJobbTilBehandlet(forespoerselId = forespoersel.forespoerselId)
                     }
                 } catch (e: Exception) {
@@ -46,7 +46,7 @@ class ForespoerselJobb(
     }
 }
 
-fun DialogportenService.opprettTransmissionForForespoersel(
+fun SykepengerDialogportenService.opprettTransmissionForForespoersel(
     forespoerselSykmeldingKobling: DokumentkoblingRepository.ForespoerselSykmeldingKobling,
 ) {
     when (forespoerselSykmeldingKobling.forespoerselStatus) {

--- a/src/main/kotlin/dokumentkobling/InntektsmeldingJobb.kt
+++ b/src/main/kotlin/dokumentkobling/InntektsmeldingJobb.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import no.nav.hag.utils.bakgrunnsjobb.RecurringJob
 import no.nav.helsearbeidsgiver.database.InntektsmeldingStatus
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.kafka.Inntektsmelding
 import no.nav.helsearbeidsgiver.metrikk.oppdaterMetrikkForAntallInntektsmeldingerMedStatusMottatt
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
@@ -18,7 +18,7 @@ import java.util.UUID
 
 class InntektsmeldingJobb(
     private val dokumentkoblingService: DokumentkoblingService,
-    private val dialogportenService: DialogportenService,
+    private val sykepengerDialogportenService: SykepengerDialogportenService,
     private val unleashFeatureToggles: UnleashFeatureToggles,
 ) : RecurringJob(CoroutineScope(Dispatchers.IO), Duration.ofSeconds(30).toMillis()) {
     override fun doJob() {
@@ -36,7 +36,7 @@ class InntektsmeldingJobb(
                 val kobling = dokumentkoblingService.hentKoblingMedForespoerselId(inntektsmelding.forespoerselId)
                 val orgnr = kobling?.let { dokumentkoblingService.hentSykmeldingOrgnr(it.sykmeldingId) }
                 if (kobling?.forespoerselJobbStatus == Status.BEHANDLET && orgnr != null) {
-                    dialogportenService.opprettTransmissionForInntektsmelding(
+                    sykepengerDialogportenService.opprettTransmissionForInntektsmelding(
                         sykmeldingId = kobling.sykmeldingId,
                         forespoerselId = kobling.forespoerselId,
                         inntektsmeldingId = inntektsmelding.inntektsmeldingId,
@@ -57,7 +57,7 @@ class InntektsmeldingJobb(
     }
 }
 
-fun DialogportenService.opprettTransmissionForInntektsmelding(
+fun SykepengerDialogportenService.opprettTransmissionForInntektsmelding(
     sykmeldingId: UUID,
     forespoerselId: UUID,
     inntektsmeldingId: UUID,

--- a/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
+++ b/src/main/kotlin/dokumentkobling/SykepengeSoeknadJobb.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import no.nav.hag.utils.bakgrunnsjobb.RecurringJob
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.metrikk.oppdaterMetrikkForAntallSykepengesoeknaderMedStatusMottatt
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -12,7 +12,7 @@ import java.time.Duration
 
 class SykepengeSoeknadJobb(
     private val dokumentkoblingRepository: DokumentkoblingRepository,
-    private val dialogportenService: DialogportenService,
+    private val sykepengerDialogportenService: SykepengerDialogportenService,
     private val unleashFeatureToggles: UnleashFeatureToggles,
 ) : RecurringJob(CoroutineScope(Dispatchers.IO), Duration.ofSeconds(30).toMillis()) {
     override fun doJob() {
@@ -31,7 +31,7 @@ class SykepengeSoeknadJobb(
                 val sykmelding = dokumentkoblingRepository.hentSykmeldingEntitet(soeknad.sykmeldingId)
 
                 if (sykmelding?.status == Status.BEHANDLET) {
-                    dialogportenService.opprettTransmissionForSoeknad(soeknad)
+                    sykepengerDialogportenService.opprettTransmissionForSoeknad(soeknad)
                     dokumentkoblingRepository.settSykepengeSoeknadJobbTilBehandlet(soeknad.soeknadId)
                 } else {
                     logger.info(
@@ -48,7 +48,7 @@ class SykepengeSoeknadJobb(
     }
 }
 
-fun DialogportenService.opprettTransmissionForSoeknad(soeknad: Sykepengesoeknad) {
+fun SykepengerDialogportenService.opprettTransmissionForSoeknad(soeknad: Sykepengesoeknad) {
     oppdaterDialogMedSykepengesoeknad(
         no.nav.helsearbeidsgiver.kafka.Sykepengesoeknad(
             soeknadId = soeknad.soeknadId,

--- a/src/main/kotlin/dokumentkobling/SykmeldingJobb.kt
+++ b/src/main/kotlin/dokumentkobling/SykmeldingJobb.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import no.nav.hag.utils.bakgrunnsjobb.RecurringJob
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.metrikk.oppdaterMetrikkForAntallSykmeldingerMedStatusMottatt
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -14,7 +14,7 @@ import no.nav.helsearbeidsgiver.kafka.Sykmeldingsperiode as SykmeldingSperiodeGa
 
 class SykmeldingJobb(
     private val dokumentkoblingRepository: DokumentkoblingRepository,
-    private val dialogportenService: DialogportenService,
+    private val sykepengerDialogportenService: SykepengerDialogportenService,
     private val unleashFeatureToggles: UnleashFeatureToggles,
 ) : RecurringJob(CoroutineScope(Dispatchers.IO), Duration.ofSeconds(30).toMillis()) {
     override fun doJob() {
@@ -29,7 +29,7 @@ class SykmeldingJobb(
 
         sykmeldinger.forEach { sykmelding ->
             try {
-                dialogportenService.opprettDialogForSykmelding(sykmelding)
+                sykepengerDialogportenService.opprettDialogForSykmelding(sykmelding)
                 dokumentkoblingRepository.settSykmeldingJobbTilBehandlet(sykmelding.sykmeldingId)
             } catch (e: Exception) {
                 "Feil ved behandling av sykmelding med id ${sykmelding.sykmeldingId}".also {
@@ -41,7 +41,7 @@ class SykmeldingJobb(
     }
 }
 
-fun DialogportenService.opprettDialogForSykmelding(sykmelding: Sykmelding) {
+fun SykepengerDialogportenService.opprettDialogForSykmelding(sykmelding: Sykmelding) {
     opprettOgLagreDialog(
         SykmeldingGammel(
             sykmeldingId = sykmelding.sykmeldingId,

--- a/src/main/kotlin/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/kafka/KafkaConsumer.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.helsesjekker.ShutDownAppState
 import no.nav.helsearbeidsgiver.kafka.kafka.DialogMeldingTolker
 import no.nav.helsearbeidsgiver.kafka.kafka.DokumentkoblingTolker
@@ -20,7 +21,7 @@ import java.time.Duration
 fun Application.configureKafkaConsumer(
     unleashFeatureToggles: UnleashFeatureToggles,
     dokumentkoblingService: DokumentkoblingService,
-    dialogportenService: DialogportenService,
+    fritakDialogportenService: FritakDialogportenService,
 ) {
     val kafkaConsumerExceptionHandler =
         CoroutineExceptionHandler { _, exception ->
@@ -43,7 +44,7 @@ fun Application.configureKafkaConsumer(
 
     launch(Dispatchers.Default + kafkaConsumerExceptionHandler) {
         startDialogKafkaConsumer(
-            dialogMeldingTolker = DialogMeldingTolker(dialogportenService),
+            dialogMeldingTolker = DialogMeldingTolker(fritakDialogportenService),
         )
     }
 }

--- a/src/main/kotlin/kafka/KafkaConsumer.kt
+++ b/src/main/kotlin/kafka/KafkaConsumer.kt
@@ -6,8 +6,6 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.nav.helsearbeidsgiver.Env
-import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.helsesjekker.ShutDownAppState
 import no.nav.helsearbeidsgiver.kafka.kafka.DialogMeldingTolker

--- a/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
+++ b/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
@@ -27,7 +27,7 @@ class DialogMeldingTolker(
             .getOrElse { e ->
                 logger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert.")
                 sikkerLogger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert. Melding: $melding", e)
-                //    throw e
+                throw e
             }
     }
 }

--- a/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
+++ b/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
@@ -27,7 +27,7 @@ class DialogMeldingTolker(
             .getOrElse { e ->
                 logger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert.")
                 sikkerLogger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert. Melding: $melding", e)
-                throw e
+                //    throw e
             }
     }
 }

--- a/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
+++ b/src/main/kotlin/kafka/kafka/DialogMeldingTolker.kt
@@ -1,13 +1,13 @@
 package no.nav.helsearbeidsgiver.kafka.kafka
 
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.kafka.DialogMelding
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.slf4j.LoggerFactory
 
 class DialogMeldingTolker(
-    val dialogportenService: DialogportenService,
+    val fritakDialogportenService: FritakDialogportenService,
 ) {
     private val logger = LoggerFactory.getLogger(DialogMeldingTolker::class.java)
     private val sikkerLogger = sikkerLogger()
@@ -23,7 +23,7 @@ class DialogMeldingTolker(
                     return
                 }
 
-        runCatching { dialogportenService.opprettDialogForFritakAgp(dekodMelding) }
+        runCatching { fritakDialogportenService.opprettDialogForFritakAgp(dekodMelding) }
             .getOrElse { e ->
                 logger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert.")
                 sikkerLogger.error("Klarte ikke sende dialog-melding til Dialogporten. Melding blir ikke prosessert. Melding: $melding", e)

--- a/src/test/kotlin/DialogportenServiceTest.kt
+++ b/src/test/kotlin/DialogportenServiceTest.kt
@@ -21,10 +21,9 @@ class DialogportenServiceTest :
         val dialogRepository = mockk<DialogRepository>(relaxed = true)
         val dialogportenClient = mockk<DialogportenClient>(relaxed = true)
         val unleashFeatureToggles = mockk<UnleashFeatureToggles>(relaxed = true)
-        val fritakDialogRepository = mockk<FritakDialogRepository>(relaxed = true)
 
         test("opprettOgLagreDialog skal kalle sykmeldingHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, fritakDialogRepository)
+            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.opprettOgLagreDialog(sykmelding)
 
@@ -32,7 +31,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedSykepengesoeknad skal kalle sykepengesoeknadHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, fritakDialogRepository)
+            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedSykepengesoeknad(sykepengesoeknad)
 
@@ -40,7 +39,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmeldingsforespoersel skal kalle forespoerselHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, fritakDialogRepository)
+            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedInntektsmeldingsforespoersel(inntektsmeldingsforespoersel)
 
@@ -48,7 +47,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmelding skal kalle inntektsmeldingHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, fritakDialogRepository)
+            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedInntektsmelding(inntektsmelding_godkjent)
 
@@ -56,7 +55,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedUtgaattForespoersel skal kalle utgaattForespoerselHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, fritakDialogRepository)
+            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedUtgaattForespoersel(forespoersel_utgaatt)
 

--- a/src/test/kotlin/DialogportenServiceTest.kt
+++ b/src/test/kotlin/DialogportenServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DialogRepository
-import no.nav.helsearbeidsgiver.database.FritakDialogRepository
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import sykepengesoeknad
 import sykmelding
@@ -23,7 +22,7 @@ class DialogportenServiceTest :
         val unleashFeatureToggles = mockk<UnleashFeatureToggles>(relaxed = true)
 
         test("opprettOgLagreDialog skal kalle sykmeldingHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.opprettOgLagreDialog(sykmelding)
 
@@ -31,7 +30,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedSykepengesoeknad skal kalle sykepengesoeknadHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedSykepengesoeknad(sykepengesoeknad)
 
@@ -39,7 +38,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmeldingsforespoersel skal kalle forespoerselHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedInntektsmeldingsforespoersel(inntektsmeldingsforespoersel)
 
@@ -47,7 +46,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmelding skal kalle inntektsmeldingHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedInntektsmelding(inntektsmelding_godkjent)
 
@@ -55,7 +54,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedUtgaattForespoersel skal kalle utgaattForespoerselHandler") {
-            val service = DialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
 
             service.oppdaterDialogMedUtgaattForespoersel(forespoersel_utgaatt)
 

--- a/src/test/kotlin/ForespoerselJobbTest.kt
+++ b/src/test/kotlin/ForespoerselJobbTest.kt
@@ -10,7 +10,7 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.ForespoerselStatus
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.dokumentkobling.ForespoerselJobb
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import java.time.LocalDateTime
@@ -18,14 +18,14 @@ import java.util.UUID
 
 class ForespoerselJobbTest :
     FunSpec({
-        val dialogportenService = mockk<DialogportenService>(relaxed = true)
+        val sykepengerDialogportenService = mockk<SykepengerDialogportenService>(relaxed = true)
         val dokumentKoblingService = mockk<DokumentkoblingService>(relaxed = true)
         val unleashFeatureToggles = UnleashFeatureToggles()
 
         val forespoerselJobb =
             ForespoerselJobb(
                 dokumentkoblingService = dokumentKoblingService,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             )
 
@@ -39,7 +39,7 @@ class ForespoerselJobbTest :
         beforeTest {
             clearAllMocks()
             every { dokumentKoblingService.hentForespoerslerKlarForBehandling() } returns emptyList()
-            every { dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any(), any()) } just runs
+            every { sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any(), any()) } just runs
             every { dokumentKoblingService.settForespoerselJobbTilBehandlet(any()) } just runs
         }
 
@@ -57,7 +57,7 @@ class ForespoerselJobbTest :
                 dokumentKoblingService.hentForespoerslerKlarForBehandling()
 
                 listOf(kobling, koblingMedSammeVedtaksperiodeId, koblingForEnHeltAnnenSak).forEach {
-                    dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
+                    sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                         it.forespoerselId,
                         it.sykmeldingId,
                     )
@@ -70,7 +70,7 @@ class ForespoerselJobbTest :
             forespoerselJobb.doJob()
 
             verify(exactly = 1) { dokumentKoblingService.hentForespoerslerKlarForBehandling() }
-            verify(exactly = 0) { dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any(), any()) }
+            verify(exactly = 0) { sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(any(), any()) }
             verify(exactly = 0) { dokumentKoblingService.settForespoerselJobbTilBehandlet(any()) }
         }
 
@@ -85,7 +85,7 @@ class ForespoerselJobbTest :
                 )
 
             every {
-                dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
+                sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                     kobling.forespoerselId,
                     kobling.sykmeldingId,
                 )
@@ -98,7 +98,7 @@ class ForespoerselJobbTest :
             // Verifiser at vi forsøkte å behandle den første forespørselen
             verify(exactly = 1) {
                 kobling.let {
-                    dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
+                    sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                         it.forespoerselId,
                         it.sykmeldingId,
                     )
@@ -108,7 +108,7 @@ class ForespoerselJobbTest :
             // Verifiser at vi ikke forsøkte å behandle den andre forespørselen med samme vedtaksperiodeId
             verify(exactly = 0) {
                 koblingMedSammeVedtaksperiodeId.let {
-                    dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
+                    sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                         it.forespoerselId,
                         it.sykmeldingId,
                     )
@@ -118,7 +118,7 @@ class ForespoerselJobbTest :
             // Verifiser at vi forsøkte å behandle den tredje forespørselen, som tilhører en annen sak
             verify(exactly = 1) {
                 koblingForEnHeltAnnenSak.let {
-                    dialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
+                    sykepengerDialogportenService.oppdaterDialogMedInntektsmeldingsforespoersel(
                         it.forespoerselId,
                         it.sykmeldingId,
                     )

--- a/src/test/kotlin/InntektsmeldingJobbTest.kt
+++ b/src/test/kotlin/InntektsmeldingJobbTest.kt
@@ -11,7 +11,7 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.InntektsmeldingStatus
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.dokumentkobling.InntektsmeldingJobb
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import java.util.UUID
@@ -19,7 +19,7 @@ import java.util.UUID
 class InntektsmeldingJobbTest :
     FunSpec({
 
-        val dialogportenService = mockk<DialogportenService>(relaxed = true)
+        val sykepengerDialogportenService = mockk<SykepengerDialogportenService>(relaxed = true)
         val dokumentkoblingService = mockk<DokumentkoblingService>(relaxed = true)
         val unleashFeatureToggles = UnleashFeatureToggles()
         val innteksmeldingResultat =
@@ -34,7 +34,7 @@ class InntektsmeldingJobbTest :
         val inntektsmeldingJobb =
             InntektsmeldingJobb(
                 dokumentkoblingService = dokumentkoblingService,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             )
 
@@ -49,13 +49,15 @@ class InntektsmeldingJobbTest :
             every { dokumentkoblingService.hentKoblingMedForespoerselId(DokumentKoblingMockUtils.forespoerselId) } returns
                 DokumentKoblingMockUtils.forespoerselSykmeldingKobling
             every { dokumentkoblingService.hentSykmeldingOrgnr(sykmeldingId) } returns DokumentKoblingMockUtils.orgnr
-            every { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
+            every { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
         }
 
         test("inntektsmeldingJobb skal opprette transmission når forespoersel er behandlet") {
             inntektsmeldingJobb.doJob()
             verify(exactly = 1) { dokumentkoblingService.hentKoblingMedForespoerselId(DokumentKoblingMockUtils.forespoerselId) }
-            verify(exactly = 1) { dialogportenService.oppdaterDialogMedInntektsmelding(match { it.sykmeldingId == sykmeldingId }) }
+            verify(
+                exactly = 1,
+            ) { sykepengerDialogportenService.oppdaterDialogMedInntektsmelding(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { dokumentkoblingService.settInntektsmeldingJobbTilBehandlet(DokumentKoblingMockUtils.inntektsmeldingId) }
         }
 
@@ -66,7 +68,7 @@ class InntektsmeldingJobbTest :
             inntektsmeldingJobb.doJob()
 
             verify(exactly = 1) { dokumentkoblingService.hentInntektsmeldingerMedStatusMottatt() }
-            verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
+            verify(exactly = 0) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { dokumentkoblingService.settInntektsmeldingJobbTilBehandlet(DokumentKoblingMockUtils.inntektsmeldingId) }
         }
 
@@ -77,7 +79,7 @@ class InntektsmeldingJobbTest :
             inntektsmeldingJobb.doJob()
 
             verify(exactly = 1) { dokumentkoblingService.hentInntektsmeldingerMedStatusMottatt() }
-            verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
+            verify(exactly = 0) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { dokumentkoblingService.settInntektsmeldingJobbTilBehandlet(DokumentKoblingMockUtils.inntektsmeldingId) }
         }
 
@@ -85,7 +87,7 @@ class InntektsmeldingJobbTest :
             val exceptionInntektsmelding = innteksmeldingResultat.copy(inntektsmeldingId = UUID.randomUUID())
 
             every {
-                dialogportenService.oppdaterDialogMedInntektsmelding(
+                sykepengerDialogportenService.oppdaterDialogMedInntektsmelding(
                     match { it.innsendingId == exceptionInntektsmelding.inntektsmeldingId },
                 )
             } throws
@@ -94,7 +96,9 @@ class InntektsmeldingJobbTest :
                 listOf(exceptionInntektsmelding, innteksmeldingResultat)
             inntektsmeldingJobb.doJob()
             verify(exactly = 2) { dokumentkoblingService.hentKoblingMedForespoerselId(DokumentKoblingMockUtils.forespoerselId) }
-            verify(exactly = 2) { dialogportenService.oppdaterDialogMedInntektsmelding(match { it.sykmeldingId == sykmeldingId }) }
+            verify(
+                exactly = 2,
+            ) { sykepengerDialogportenService.oppdaterDialogMedInntektsmelding(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { dokumentkoblingService.settInntektsmeldingJobbTilBehandlet(DokumentKoblingMockUtils.inntektsmeldingId) }
         }
     })

--- a/src/test/kotlin/SykepengeSoeknadJobbTest.kt
+++ b/src/test/kotlin/SykepengeSoeknadJobbTest.kt
@@ -11,7 +11,7 @@ import io.mockk.runs
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.SykmeldingEntity
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import java.util.UUID
 
@@ -19,13 +19,13 @@ class SykepengeSoeknadJobbTest :
     FunSpec({
 
         val repository = mockk<DokumentkoblingRepository>()
-        val dialogportenService = mockk<DialogportenService>(relaxed = true)
+        val sykepengerDialogportenService = mockk<SykepengerDialogportenService>(relaxed = true)
         val unleashFeatureToggles = UnleashFeatureToggles()
 
         val sykepengeSoeknadJobb =
             SykepengeSoeknadJobb(
                 dokumentkoblingRepository = repository,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             )
 
@@ -44,7 +44,7 @@ class SykepengeSoeknadJobbTest :
             every { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() } returns
                 listOf(DokumentKoblingMockUtils.soeknad)
             every { repository.hentSykmeldingEntitet(sykmeldingId) } returns sykmeldingEntity
-            every { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
+            every { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) } just runs
         }
 
         test("sykepengesoeknadJobb skal opprette transmission når sykmelding er behandlet") {
@@ -54,7 +54,9 @@ class SykepengeSoeknadJobbTest :
             sykepengeSoeknadJobb.doJob()
 
             verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
-            verify(exactly = 1) { dialogportenService.oppdaterDialogMedSykepengesoeknad(match { it.sykmeldingId == sykmeldingId }) }
+            verify(
+                exactly = 1,
+            ) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
 
@@ -65,7 +67,7 @@ class SykepengeSoeknadJobbTest :
             sykepengeSoeknadJobb.doJob()
 
             verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
-            verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
+            verify(exactly = 0) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
 
@@ -76,7 +78,7 @@ class SykepengeSoeknadJobbTest :
             sykepengeSoeknadJobb.doJob()
 
             verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
-            verify(exactly = 0) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
+            verify(exactly = 0) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 0) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
 
@@ -88,13 +90,13 @@ class SykepengeSoeknadJobbTest :
 
             every { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() } returns
                 listOf(exceptionSoeknad, DokumentKoblingMockUtils.soeknad)
-            every { dialogportenService.opprettTransmissionForSoeknad(exceptionSoeknad) } throws
+            every { sykepengerDialogportenService.opprettTransmissionForSoeknad(exceptionSoeknad) } throws
                 NotFoundException("Fant ikke sykmelding for søknad")
 
             sykepengeSoeknadJobb.doJob()
 
             verify(exactly = 1) { repository.henteSykepengeSoeknaderMedStatusMottattPartisjonertTilfeldig() }
-            verify(exactly = 2) { dialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
+            verify(exactly = 2) { sykepengerDialogportenService.oppdaterDialogMedSykepengesoeknad(any()) }
             verify(exactly = 1) { repository.settSykepengeSoeknadJobbTilBehandlet(soeknadId) }
         }
     })

--- a/src/test/kotlin/SykmeldingJobbTest.kt
+++ b/src/test/kotlin/SykmeldingJobbTest.kt
@@ -1,5 +1,4 @@
 import dokumentkobling.SykmeldingJobb
-import io.getunleash.FakeUnleash
 import io.kotest.core.spec.style.FunSpec
 import io.ktor.server.plugins.NotFoundException
 import io.mockk.clearAllMocks
@@ -9,7 +8,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import java.util.UUID
 
@@ -17,13 +16,13 @@ class SykmeldingJobbTest :
     FunSpec({
 
         val repository = mockk<DokumentkoblingRepository>()
-        val dialogportenService = mockk<DialogportenService>(relaxed = true)
+        val sykepengerDialogportenService = mockk<SykepengerDialogportenService>(relaxed = true)
         val unleashFeatureToggles = UnleashFeatureToggles()
 
         val sykmeldingJobb =
             SykmeldingJobb(
                 dokumentkoblingRepository = repository,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             )
 
@@ -32,7 +31,7 @@ class SykmeldingJobbTest :
         beforeTest {
             clearAllMocks()
             every { repository.henteSykemeldingerMedStatusMottatt() } returns listOf(DokumentKoblingMockUtils.sykmelding)
-            every { dialogportenService.opprettOgLagreDialog(any()) } just runs
+            every { sykepengerDialogportenService.opprettOgLagreDialog(any()) } just runs
             every { repository.settSykmeldingJobbTilBehandlet(any()) } just runs
         }
 
@@ -41,7 +40,7 @@ class SykmeldingJobbTest :
             sykmeldingJobb.doJob()
 
             verify(exactly = 1) { repository.henteSykemeldingerMedStatusMottatt() }
-            verify(exactly = 1) { dialogportenService.opprettOgLagreDialog(match { it.sykmeldingId == sykmeldingId }) }
+            verify(exactly = 1) { sykepengerDialogportenService.opprettOgLagreDialog(match { it.sykmeldingId == sykmeldingId }) }
             verify(exactly = 1) { repository.settSykmeldingJobbTilBehandlet(sykmeldingId) }
         }
 
@@ -49,7 +48,7 @@ class SykmeldingJobbTest :
 
             val exceptionSykmeldingId = UUID.randomUUID()
             val exceptionSykmelding = DokumentKoblingMockUtils.sykmelding.copy(exceptionSykmeldingId)
-            every { dialogportenService.opprettOgLagreDialog(match { it.sykmeldingId == exceptionSykmeldingId }) } throws
+            every { sykepengerDialogportenService.opprettOgLagreDialog(match { it.sykmeldingId == exceptionSykmeldingId }) } throws
                 NotFoundException("Feil ved henting")
 
             every { repository.henteSykemeldingerMedStatusMottatt() } returns
@@ -60,7 +59,7 @@ class SykmeldingJobbTest :
 
             sykmeldingJobb.doJob()
             verify(exactly = 1) { repository.henteSykemeldingerMedStatusMottatt() }
-            verify(exactly = 2) { dialogportenService.opprettOgLagreDialog(any()) }
+            verify(exactly = 2) { sykepengerDialogportenService.opprettOgLagreDialog(any()) }
             verify(exactly = 1) { repository.settSykmeldingJobbTilBehandlet(sykmeldingId) }
         }
     })

--- a/src/test/kotlin/dialogporten/handlers/FritakAgpKravHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/FritakAgpKravHandlerTest.kt
@@ -254,7 +254,7 @@ class FritakAgpKravHandlerTest :
             coVerify(exactly = 0) { dialogportenClientMock.replaceAttachmentsAndActions(any(), any(), any(), any()) }
         }
 
-        test("skal ikke gjøre noe når KroniskKravSlettet ikke finner opprinnelig krav") {
+        test("skal opprette ny dialog når KroniskKravSlettet ikke finner opprinnelig krav") {
             val kravId = UUID.randomUUID()
             val kravmelding =
                 KroniskKravSlettet(id = kravId, orgnr = orgnr, navn = "Ola Nordmann", fnr = Fnr.genererGyldig().verdi)
@@ -263,12 +263,13 @@ class FritakAgpKravHandlerTest :
 
             handler.behandleKravDialog(kravmelding)
 
-            coVerify(exactly = 0) { dialogportenClientMock.addTransmission(any(), any<Transmission>()) }
-            coVerify(exactly = 0) { dialogportenClientMock.removeActionsAndStatus(any()) }
-            verify(exactly = 0) { fritakDialogRepositoryMock.lagreKravDialog(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) { dialogportenClientMock.createDialog(any<CreateDialogRequest>()) }
+            coVerify(exactly = 1) { dialogportenClientMock.addTransmission(dialogId, any<Transmission>()) }
+            coVerify(exactly = 0) { dialogportenClientMock.addGuiAction(dialogId, any<GuiAction>()) }
+            coVerify(exactly = 0) { dialogportenClientMock.replaceAttachmentsAndActions(any(), any(), any(), any()) }
         }
 
-        test("skal ikke gjøre noe når GravidKravSlettet ikke finner opprinnelig krav") {
+        test("skal opprette ny dialog når GravidKravSlettet ikke finner opprinnelig krav") {
             val kravId = UUID.randomUUID()
             val kravmelding =
                 GravidKravSlettet(id = kravId, orgnr = orgnr, navn = "Kari Nordmann", fnr = Fnr.genererGyldig().verdi)
@@ -276,9 +277,9 @@ class FritakAgpKravHandlerTest :
             every { fritakDialogRepositoryMock.finnDialogMedKravId(kravId) } returns null
 
             handler.behandleKravDialog(kravmelding)
-
-            coVerify(exactly = 0) { dialogportenClientMock.addTransmission(any(), any<Transmission>()) }
-            coVerify(exactly = 0) { dialogportenClientMock.removeActionsAndStatus(any()) }
-            verify(exactly = 0) { fritakDialogRepositoryMock.lagreKravDialog(any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) { dialogportenClientMock.createDialog(any<CreateDialogRequest>()) }
+            coVerify(exactly = 1) { dialogportenClientMock.addTransmission(dialogId, any<Transmission>()) }
+            coVerify(exactly = 0) { dialogportenClientMock.addGuiAction(dialogId, any<GuiAction>()) }
+            coVerify(exactly = 0) { dialogportenClientMock.replaceAttachmentsAndActions(any(), any(), any(), any()) }
         }
     })

--- a/src/test/kotlin/local/AppLokal.kt
+++ b/src/test/kotlin/local/AppLokal.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.Transmission
 import no.nav.helsearbeidsgiver.helsesjekker.HelsesjekkService
@@ -62,7 +63,11 @@ fun startServer() {
             dialogRepository = dialogRepository,
             dialogportenClient = dialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
+        )
+    val fritakDialogportenService =
+        FritakDialogportenService(
             fritakDialogRepository = fritakDialogRepository,
+            dialogportenClient = dialogportenClient,
         )
     val dokumentkoblingService =
         dokumentkobling.DokumentkoblingService(
@@ -85,7 +90,7 @@ fun startServer() {
             routing {
                 naisRoutes(HelsesjekkService(database.db))
             }
-            configureKafkaConsumer(unleashFeatureToggles, dokumentkoblingService, dialogportenService)
+            configureKafkaConsumer(unleashFeatureToggles, dokumentkoblingService, fritakDialogportenService)
             startRecurringJobs(jobber)
             monitor.subscribe(ApplicationStopPreparing) {
                 logger.info("Applikasjonen stopper, avslutter eventuelle jobber...")

--- a/src/test/kotlin/local/AppLokal.kt
+++ b/src/test/kotlin/local/AppLokal.kt
@@ -12,8 +12,8 @@ import no.nav.helsearbeidsgiver.database.Database
 import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
-import no.nav.helsearbeidsgiver.dialogporten.DialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.Transmission
 import no.nav.helsearbeidsgiver.helsesjekker.HelsesjekkService
@@ -58,8 +58,8 @@ fun startServer() {
             .FritakDialogRepository(database.db)
     val dokumentkoblingRepository = DokumentkoblingRepository(db = database.db, maksAntallPerHenting = 1000)
 
-    val dialogportenService =
-        DialogportenService(
+    val sykepengerDialogportenService =
+        SykepengerDialogportenService(
             dialogRepository = dialogRepository,
             dialogportenClient = dialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
@@ -77,7 +77,7 @@ fun startServer() {
         listOf(
             SykepengeSoeknadJobb(
                 dokumentkoblingRepository = dokumentkoblingRepository,
-                dialogportenService = dialogportenService,
+                sykepengerDialogportenService = sykepengerDialogportenService,
                 unleashFeatureToggles = unleashFeatureToggles,
             ),
         )

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,5 +3,6 @@ application {
 }
 
 ALTINN_3_BASE_URL = "https://platform.tt02.altinn.no"
-ALTINN_DIALOGPORTEN_RESSURS = "altinn-dialogporten"
 DIALOGPORTEN_SCOPE = "altinn:serviceowner/altinn-dialogporten/.default"
+FRITAK_AGP_DIALOGPORTEN_RESSURS = "fritak-agp-ressurs"
+SYKEPENGER_DIALOGPORTEN_RESSURS = "sykepenger-ressurs"


### PR DESCRIPTION
## Ny ressurs for Fritak AGP og annullering av krav

Denne PR-en innfører i hovedsak ny ressurs for Fritak AGP-dialogmeldinger. Begrepet "slettet" er endret til "annullert" for å være i samsvar med skjemaet på nav.no.

### Endringer

- Delte opp den originale `DialogportenService` i `SykepengerDialogportenService` og `FritakDialogportenService`, hver med sin egen klient og repository, for bedre separasjon av domenelogikk
- Oppdaterte miljøvariabler for å skille mellom Sykepenger- og Fritak AGP-ressurser
- Endret knappetekst fra `"Endre krav"` til `"Endre / Annuller krav"` i Fritak AGP-dialoger
- Knappen vises kun når det er hensiktsmessig — ikke for annullerte krav
- Forbedret håndtering av annullerte krav: oppretter ny dialog dersom opprinnelig ikke finnes, og logger dette
- Oppdaterte dialogtitler til å bruke `"annullert"` i stedet for `"slettet"` for annullerte Fritak AGP-krav, i tråd med korrekt forretningsterminologi