### PR TITLE
Sykepenger dialog endre på ordlyd

### DIFF
--- a/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
+++ b/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
@@ -85,7 +85,7 @@ fun Inntektsmelding.Status.toTittel(): String =
 fun Inntektsmelding.Status.toTransmissionType(): Transmission.TransmissionType =
     when (this) {
         Inntektsmelding.Status.FEILET -> Transmission.TransmissionType.Rejection
-        Inntektsmelding.Status.GODKJENT -> Transmission.TransmissionType.Acceptance
+        Inntektsmelding.Status.GODKJENT -> Transmission.TransmissionType.Submission
     }
 
 class InntektsmeldingTransmissionRequest(

--- a/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
+++ b/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
@@ -79,7 +79,7 @@ fun Inntektsmelding.Status.toExtendedType(): String =
 fun Inntektsmelding.Status.toTittel(): String =
     when (this) {
         Inntektsmelding.Status.FEILET -> "Inntektsmelding avvist"
-        Inntektsmelding.Status.GODKJENT -> "Inntektsmelding godkjent"
+        Inntektsmelding.Status.GODKJENT -> "Inntektsmelding mottatt"
     }
 
 fun Inntektsmelding.Status.toTransmissionType(): Transmission.TransmissionType =

--- a/src/main/kotlin/dialogporten/handlers/ForespoerselHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/ForespoerselHandler.kt
@@ -47,7 +47,7 @@ class ForespoerselHandler(
                 dialogId = dialog.dialogId,
                 apiAction =
                     ApiAction(
-                        name = "Send inn inntektsmelding",
+                        name = "Se og endre inntektsmelding",
                         endpoints =
                             listOf(
                                 ApiAction.Endpoint(
@@ -60,10 +60,10 @@ class ForespoerselHandler(
                     ),
                 guiAction =
                     GuiAction(
-                        name = "Send inn inntektsmelding",
+                        name = "Se og endre inntektsmelding",
                         url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/$forespoerselId",
                         action = Action.READ.value,
-                        title = listOf(ContentValueItem("Send inn inntektsmelding")),
+                        title = listOf(ContentValueItem("Se og endre inntektsmelding")),
                         priority = GuiAction.Priority.Primary,
                     ),
             )

--- a/src/main/kotlin/dialogporten/handlers/ForespoerselHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/ForespoerselHandler.kt
@@ -47,7 +47,7 @@ class ForespoerselHandler(
                 dialogId = dialog.dialogId,
                 apiAction =
                     ApiAction(
-                        name = "Se og endre inntektsmelding",
+                        name = "Send inn inntektsmelding",
                         endpoints =
                             listOf(
                                 ApiAction.Endpoint(
@@ -60,10 +60,10 @@ class ForespoerselHandler(
                     ),
                 guiAction =
                     GuiAction(
-                        name = "Se og endre inntektsmelding",
+                        name = "Send inn inntektsmelding",
                         url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/$forespoerselId",
                         action = Action.READ.value,
-                        title = listOf(ContentValueItem("Se og endre inntektsmelding")),
+                        title = listOf(ContentValueItem("Send inn inntektsmelding")),
                         priority = GuiAction.Priority.Primary,
                     ),
             )

--- a/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
@@ -5,7 +5,10 @@ import no.nav.helsearbeidsgiver.Env
 import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.InntektsmeldingTransmissionRequest
+import no.nav.helsearbeidsgiver.dialogporten.domene.Action
+import no.nav.helsearbeidsgiver.dialogporten.domene.ContentValueItem
 import no.nav.helsearbeidsgiver.dialogporten.domene.DialogStatus
+import no.nav.helsearbeidsgiver.dialogporten.domene.GuiAction
 import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
@@ -53,6 +56,23 @@ class InntektsmeldingHandler(
                         ),
                     ).also {
                         dialogportenClient.setDialogStatus(dialog.dialogId, DialogStatus.NotApplicable)
+                        if (inntektsmelding.status == Inntektsmelding.Status.GODKJENT) {
+                            dialogportenClient.replaceAttachmentsAndActions(
+                                dialogId = dialog.dialogId,
+                                attachments = emptyList(),
+                                apiActions = emptyList(),
+                                guiActions =
+                                    listOf(
+                                        GuiAction(
+                                            name = "Se og endre inntektsmelding",
+                                            url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/${inntektsmelding.forespoerselId}",
+                                            action = Action.READ.value,
+                                            title = listOf(ContentValueItem("Se og endre inntektsmelding")),
+                                            priority = GuiAction.Priority.Secondary,
+                                        ),
+                                    ),
+                            )
+                        }
                     }
             }
 

--- a/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
@@ -75,19 +75,26 @@ class InntektsmeldingHandler(
 fun inntektsmeldingTransmissionRequest(
     inntektsmelding: Inntektsmelding,
     relatedTransmissionId: UUID?,
-): TransmissionRequest =
-    InntektsmeldingTransmissionRequest(
+): TransmissionRequest {
+    val apiAttachment =
+        createApiAttachment(
+            displayName = "inntektsmelding.json",
+            url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/inntektsmelding/${inntektsmelding.innsendingId}",
+        )
+    val guiAttachment =
+        createGuiAttachment(
+            displayName = "Se inntektsmelding i Arbeidsgiverportalen",
+            url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/${inntektsmelding.forespoerselId}",
+        )
+    val attachments =
+        if (inntektsmelding.status == Inntektsmelding.Status.FEILET) {
+            listOf(apiAttachment) // feilet så vises bare for API, ikke i GUI.
+        } else {
+            listOf(apiAttachment, guiAttachment)
+        }
+    return InntektsmeldingTransmissionRequest(
         inntektsmelding = inntektsmelding,
         relatedTransmissionId = relatedTransmissionId,
-        attachments =
-            listOf(
-                createApiAttachment(
-                    displayName = "inntektsmelding.json",
-                    url = "${Env.Nav.arbeidsgiverApiBaseUrl}/v1/inntektsmelding/${inntektsmelding.innsendingId}",
-                ),
-                createGuiAttachment(
-                    displayName = "Se inntektsmelding i Arbeidsgiverportalen",
-                    url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/${inntektsmelding.forespoerselId}",
-                ),
-            ),
+        attachments = attachments,
     )
+}

--- a/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/InntektsmeldingHandler.kt
@@ -57,6 +57,7 @@ class InntektsmeldingHandler(
                     ).also {
                         dialogportenClient.setDialogStatus(dialog.dialogId, DialogStatus.NotApplicable)
                         if (inntektsmelding.status == Inntektsmelding.Status.GODKJENT) {
+                            val attachmentNavn = "Se og endre inntektsmelding"
                             dialogportenClient.replaceAttachmentsAndActions(
                                 dialogId = dialog.dialogId,
                                 attachments = emptyList(),
@@ -64,10 +65,10 @@ class InntektsmeldingHandler(
                                 guiActions =
                                     listOf(
                                         GuiAction(
-                                            name = "Se og endre inntektsmelding",
+                                            name = attachmentNavn,
                                             url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/${inntektsmelding.forespoerselId}",
                                             action = Action.READ.value,
-                                            title = listOf(ContentValueItem("Se og endre inntektsmelding")),
+                                            title = listOf(ContentValueItem(attachmentNavn)),
                                             priority = GuiAction.Priority.Secondary,
                                         ),
                                     ),
@@ -103,7 +104,7 @@ fun inntektsmeldingTransmissionRequest(
         )
     val guiAttachment =
         createGuiAttachment(
-            displayName = "Se inntektsmelding i Arbeidsgiverportalen",
+            displayName = "Se og endre inntektsmelding",
             url = "${Env.Nav.arbeidsgiverGuiBaseUrl}/im-dialog/${inntektsmelding.forespoerselId}",
         )
     val attachments =

--- a/src/test/kotlin/dialogporten/handlers/InntektsmeldingHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/InntektsmeldingHandlerTest.kt
@@ -53,6 +53,7 @@ class InntektsmeldingHandlerTest :
             every { dialogRepositoryMock.finnDialogMedSykemeldingId(inntektsmelding_godkjent.sykmeldingId) } returns dialogEntity
             coEvery { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) } returns transmissionId
             coEvery { dialogportenClientMock.setDialogStatus(any(), any()) } just Runs
+            coEvery { dialogportenClientMock.replaceAttachmentsAndActions(any(), any(), any(), any()) } just Runs
             every { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) } just Runs
 
             inntektsmeldingHandler.oppdaterDialog(inntektsmelding_godkjent)


### PR DESCRIPTION
**Problem:**
Vi kommer snart til å sette sykepenger dialog i prod og noen av tekstene i løsningen kan være forvirrende for brukere.
Det står "Inntektsmelding godkjent" som kan skape forvirring da inntektsmeldingen kan inneholde datafeil som en saksbehandler finner senere.
Vi spør brukeren med en primary knapp om å send inn inntektsmelding selv om de har allerede sendt inn. 
En intern valideringsfeil vises som at "inntektsmelding avvist". Dette kan være forvirrende for bruker.

**Løsning:**
- Godkjent inntektsmelding transmisjonstype endret fra Acceptance → Submission
- GUI-handling erstattes med sekundær "Se og endre inntektsmelding"-knapp
- Avvist (FEILET): Kun API-vedlegg sendes, ingen GUI-vedlegg vises


**Skjermbilde:**
Viser at GUI action er endret og avvist melding gjemt og ordlyd byttet til mottatt. 
<img width="1454" height="1111" alt="image" src="https://github.com/user-attachments/assets/e7f892f6-5253-4897-8673-6dae6b12e695" />
