### PR TITLE
skrur på auditlogging for database i prod

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -61,6 +61,13 @@ spec:
         diskAutoresize: true
         databases:
           - name: dialog
+        flags:
+          - name: "cloudsql.enable_pgaudit"
+            value: "on"
+          - name: "pgaudit.log"
+            value: "write,ddl,role"
+          - name: "pgaudit.log_parameter"
+            value: "on"
   envFrom:
     - secret: dialog-unleash-api-token
   env:


### PR DESCRIPTION
Det er ønskelig at alle databaser i produksjon kjører med audit-logging skrudd på.