### PR TITLE
Gjør dialog appen mer robust mot midlertidlig nedetid i andre apper 

### DIFF
--- a/src/main/kotlin/dokumentkobling/AvbrytDokumentJobb.kt
+++ b/src/main/kotlin/dokumentkobling/AvbrytDokumentJobb.kt
@@ -8,7 +8,7 @@ import java.time.Duration
 import java.time.LocalDateTime
 
 private const val ANTALL_MINUTTER_MELLOM_KJOERINGER = 1L
-private const val ANTALL_MINUTTER_FOER_TIDSAVBRUDD = 60L
+private const val ANTALL_MINUTTER_FOER_TIDSAVBRUDD = 2880L // 2 dager
 
 abstract class AvbrytDokumentJobb(
     private val dokumentNavn: String,

--- a/src/main/kotlin/dokumentkobling/AvbrytDokumentJobb.kt
+++ b/src/main/kotlin/dokumentkobling/AvbrytDokumentJobb.kt
@@ -7,7 +7,7 @@ import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import java.time.Duration
 import java.time.LocalDateTime
 
-private const val ANTALL_MINUTTER_MELLOM_KJOERINGER = 1L
+private const val ANTALL_MINUTTER_MELLOM_KJOERINGER = 60L
 private const val ANTALL_MINUTTER_FOER_TIDSAVBRUDD = 2880L // 2 dager
 
 abstract class AvbrytDokumentJobb(


### PR DESCRIPTION
**Problem:**
Vi satt en tilfeldig tidsavbrutt tid på 1 time når vi utviklet dialog appen.
Tidsavbrutt tid lar dialog appen håndtere midlertidlig nedetid i andre tjenester slik som altinn, flex eller sas.
Det er sansynlig at nedetid kan vare i mer enn én time.
Om det nå oppstår nedetid i over en time må vi gjøre manuelle endringer i prod databasen, noe som ikke er ønskelig.
Brukere vil også ikke få altinn meldinger før vi manuelt fikser databasen om det oppstår nedetid i over en time

**Løsning:**
Øke tidsavbrutt tiden til 2 dager