### PR TITLE
Legg til forklarende additionalInfo i dialog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinterVersion=5.2.0
 
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
-dialogportenClientVersion=2.6.5
+dialogportenClientVersion=2.6.6-SNAPSHOT
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinterVersion=5.2.0
 
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
-dialogportenClientVersion=2.6.6-SNAPSHOT
+dialogportenClientVersion=2.6.6
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -11,7 +11,8 @@ import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.kafka.Sykmelding
-import no.nav.helsearbeidsgiver.kafka.lagDialogSummary
+import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
+import no.nav.helsearbeidsgiver.kafka.lagDialogAdditionalInfo
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
@@ -34,7 +35,8 @@ class SykmeldingHandler(
                         title =
                             "Sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})",
                         summary =
-                            sykmelding.sykmeldingsperioder.lagDialogSummary(),
+                            sykmelding.sykmeldingsperioder.getSykmeldingsPerioderString(),
+                        additionalInfo = lagDialogAdditionalInfo(),
                         transmissions =
                             listOf(
                                 sykmeldingTransmission(sykmelding).toTransmission(),

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -11,7 +11,7 @@ import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.kafka.Sykmelding
-import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
+import no.nav.helsearbeidsgiver.kafka.lagDialogSummary
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
@@ -34,8 +34,7 @@ class SykmeldingHandler(
                         title =
                             "Sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})",
                         summary =
-                            sykmelding.sykmeldingsperioder
-                                .getSykmeldingsPerioderString(),
+                            sykmelding.sykmeldingsperioder.lagDialogSummary(),
                         transmissions =
                             listOf(
                                 sykmeldingTransmission(sykmelding).toTransmission(),

--- a/src/main/kotlin/kafka/Melding.kt
+++ b/src/main/kotlin/kafka/Melding.kt
@@ -79,7 +79,18 @@ data class Inntektsmelding(
 
 fun List<Sykmeldingsperiode>.getSykmeldingsPerioderString(): String =
     when (size) {
-        1 -> "Sykmeldingsperiode ${first().fom.tilNorskFormat()} – ${first().tom.tilNorskFormat()}"
-        else ->
-            "Sykmeldingsperioder ${first().fom.tilNorskFormat()} – (...) – ${last().tom.tilNorskFormat()}"
+        1 -> {
+            "sykmeldingsperiode ${first().fom.tilNorskFormat()} – ${first().tom.tilNorskFormat()}"
+        }
+
+        else -> {
+            "sykmeldingsperioder ${first().fom.tilNorskFormat()} – (...) – ${last().tom.tilNorskFormat()}"
+        }
     }
+
+fun List<Sykmeldingsperiode>.lagDialogSummary(): String =
+    """
+    Gjelder ${getSykmeldingsPerioderString()}
+    NAV samler nå sykmelding, søknad og inntektsmelding i én felles melding i Altinn-innboksen. Meldingen inneholder alltid sykmelding. Søknad om sykepenger blir tilgjengelig når den ansatte har søkt, og du kan sende inntektsmelding herfra når Nav har behov for det. Meldingen blir oppdatert automatisk. 
+    Fra og med 15. juni 2026 vises sykmelding og søknad kun her, og ikke lenger som separate meldinger i innboksen.    
+    """.trimIndent()

--- a/src/main/kotlin/kafka/Melding.kt
+++ b/src/main/kotlin/kafka/Melding.kt
@@ -91,6 +91,8 @@ fun List<Sykmeldingsperiode>.getSykmeldingsPerioderString(): String =
 fun List<Sykmeldingsperiode>.lagDialogSummary(): String =
     """
     Gjelder ${getSykmeldingsPerioderString()}
+    
     NAV samler sykmelding, søknad og inntektsmelding i én felles melding i Altinn som oppdateres automatisk.
+    
     Fra 15. juni vises disse kun her, ikke som separate meldinger i innboksen.  
     """.trimIndent()

--- a/src/main/kotlin/kafka/Melding.kt
+++ b/src/main/kotlin/kafka/Melding.kt
@@ -80,19 +80,17 @@ data class Inntektsmelding(
 fun List<Sykmeldingsperiode>.getSykmeldingsPerioderString(): String =
     when (size) {
         1 -> {
-            "sykmeldingsperiode ${first().fom.tilNorskFormat()} – ${first().tom.tilNorskFormat()}"
+            "Gjelder sykmeldingsperiode ${first().fom.tilNorskFormat()} – ${first().tom.tilNorskFormat()}"
         }
 
         else -> {
-            "sykmeldingsperioder ${first().fom.tilNorskFormat()} – (...) – ${last().tom.tilNorskFormat()}"
+            "Gjelder sykmeldingsperioder ${first().fom.tilNorskFormat()} – (...) – ${last().tom.tilNorskFormat()}"
         }
     }
 
-fun List<Sykmeldingsperiode>.lagDialogSummary(): String =
+fun lagDialogAdditionalInfo(): String =
     """
-    Gjelder ${getSykmeldingsPerioderString()}
-    
-    NAV samler sykmelding, søknad og inntektsmelding i én felles melding i Altinn som oppdateres automatisk.
-    
-    Fra 15. juni vises disse kun her, ikke som separate meldinger i innboksen.  
+    *NAV samler nå sykmelding, søknad og inntektsmelding i én felles melding i Altinn-innboksen. Meldingen inneholder alltid sykmelding. Søknad om sykepenger blir tilgjengelig når den ansatte har søkt, og du kan sende inntektsmelding herfra når Nav har behov for det. Meldingen blir oppdatert automatisk.*  
+         
+    *Fra og med 15. juni 2026 vises sykmelding og søknad kun her, og ikke lenger som separate meldinger i innboksen.*
     """.trimIndent()

--- a/src/main/kotlin/kafka/Melding.kt
+++ b/src/main/kotlin/kafka/Melding.kt
@@ -90,7 +90,7 @@ fun List<Sykmeldingsperiode>.getSykmeldingsPerioderString(): String =
 
 fun lagDialogAdditionalInfo(): String =
     """
-    *NAV samler nå sykmelding, søknad og inntektsmelding i én felles melding i Altinn-innboksen. Meldingen inneholder alltid sykmelding. Søknad om sykepenger blir tilgjengelig når den ansatte har søkt, og du kan sende inntektsmelding herfra når Nav har behov for det. Meldingen blir oppdatert automatisk.*  
+    *Nav samler nå sykmelding, søknad og inntektsmelding i én felles melding i Altinn-innboksen. Meldingen inneholder alltid sykmelding. Søknad om sykepenger blir tilgjengelig når den ansatte har søkt. Hvis Nav trenger inntektsmelding, vil meldingen også inkludere lenke til innsendingsskjema på nav.no*  
          
     *Fra og med 15. juni 2026 vises sykmelding og søknad kun her, og ikke lenger som separate meldinger i innboksen.*
     """.trimIndent()

--- a/src/main/kotlin/kafka/Melding.kt
+++ b/src/main/kotlin/kafka/Melding.kt
@@ -91,6 +91,6 @@ fun List<Sykmeldingsperiode>.getSykmeldingsPerioderString(): String =
 fun List<Sykmeldingsperiode>.lagDialogSummary(): String =
     """
     Gjelder ${getSykmeldingsPerioderString()}
-    NAV samler nå sykmelding, søknad og inntektsmelding i én felles melding i Altinn-innboksen. Meldingen inneholder alltid sykmelding. Søknad om sykepenger blir tilgjengelig når den ansatte har søkt, og du kan sende inntektsmelding herfra når Nav har behov for det. Meldingen blir oppdatert automatisk. 
-    Fra og med 15. juni 2026 vises sykmelding og søknad kun her, og ikke lenger som separate meldinger i innboksen.    
+    NAV samler sykmelding, søknad og inntektsmelding i én felles melding i Altinn som oppdateres automatisk.
+    Fra 15. juni vises disse kun her, ikke som separate meldinger i innboksen.  
     """.trimIndent()

--- a/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
@@ -14,7 +14,7 @@ import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykmeldingHandler
-import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
+import no.nav.helsearbeidsgiver.kafka.lagDialogSummary
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
 import sykmelding
@@ -50,7 +50,7 @@ class SykmeldingHandlerTest :
             capturedRequest.orgnr shouldBe sykmelding.orgnr
             capturedRequest.externalReference shouldBe sykmelding.sykmeldingId.toString()
             capturedRequest.title shouldBe "Sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
-            capturedRequest.summary shouldBe sykmelding.sykmeldingsperioder.getSykmeldingsPerioderString()
+            capturedRequest.summary shouldBe sykmelding.sykmeldingsperioder.lagDialogSummary()
             capturedRequest.isApiOnly shouldBe true
 
             verify(exactly = 1) {

--- a/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
@@ -14,7 +14,7 @@ import no.nav.helsearbeidsgiver.database.DialogRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykmeldingHandler
-import no.nav.helsearbeidsgiver.kafka.lagDialogSummary
+import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
 import sykmelding
@@ -50,7 +50,7 @@ class SykmeldingHandlerTest :
             capturedRequest.orgnr shouldBe sykmelding.orgnr
             capturedRequest.externalReference shouldBe sykmelding.sykmeldingId.toString()
             capturedRequest.title shouldBe "Sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
-            capturedRequest.summary shouldBe sykmelding.sykmeldingsperioder.lagDialogSummary()
+            capturedRequest.summary shouldBe sykmelding.sykmeldingsperioder.getSykmeldingsPerioderString()
             capturedRequest.isApiOnly shouldBe true
 
             verify(exactly = 1) {


### PR DESCRIPTION
**Problem:**
Vi skal prodsette dialoger til GUI brukere i altinn innboksen.
Disse brukerne kommer til å bli forvirret av at det kommer duplikat meldinger (pga gamle correspondence)
Brukerne har ikke erfaring på den nye dialogporten meldingen der alt er samlet

**Løsning:**
Legg til en beskrivende tekst i summary der vi forklarer dette til bruker