### PR TITLE
fjern apiOnly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinterVersion=5.2.0
 
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
-dialogportenClientVersion=2.6.7-SNAPSHOT
+dialogportenClientVersion=2.6.7
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinterVersion=5.2.0
 
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
-dialogportenClientVersion=2.6.6
+dialogportenClientVersion=2.6.7-SNAPSHOT
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -19,6 +19,7 @@ class SykepengesoeknadHandler(
     private val logger = logger()
 
     fun oppdaterDialog(sykepengesoeknad: Sykepengesoeknad) {
+        // TODO: Hvis ikke finnes - lage???
         val dialog =
             dialogRepository.finnDialogMedSykemeldingId(sykmeldingId = sykepengesoeknad.sykmeldingId)
                 ?: run {
@@ -31,6 +32,7 @@ class SykepengesoeknadHandler(
 
         val transmissionId =
             runBlocking {
+                dialogportenClient.fjernApiOnly(dialog.dialogId)
                 dialogportenClient.addTransmission(
                     dialogId = dialog.dialogId,
                     transmissionRequest = sykepengesoknadTransmission(sykepengesoeknad = sykepengesoeknad),

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -32,7 +32,7 @@ class SykepengesoeknadHandler(
 
         val transmissionId =
             runBlocking {
-                dialogportenClient.fjernApiOnly(dialog.dialogId)
+                dialogportenClient.removeApiOnly(dialog.dialogId)
                 dialogportenClient.addTransmission(
                     dialogId = dialog.dialogId,
                     transmissionRequest = sykepengesoknadTransmission(sykepengesoeknad = sykepengesoeknad),

--- a/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
@@ -42,7 +42,7 @@ class SykepengesoeknadHandlerTest :
 
             every { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) } returns dialogEntity
             coEvery { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) } returns transmissionId
-            coEvery { dialogportenClientMock.fjernApiOnly(any()) } just Runs
+            coEvery { dialogportenClientMock.removeApiOnly(any()) } just Runs
             every { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) } just Runs
 
             sykepengeSoeknadhandler.oppdaterDialog(sykepengesoeknad)

--- a/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
@@ -42,6 +42,7 @@ class SykepengesoeknadHandlerTest :
 
             every { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) } returns dialogEntity
             coEvery { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) } returns transmissionId
+            coEvery { dialogportenClientMock.fjernApiOnly(any()) } just Runs
             every { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) } just Runs
 
             sykepengeSoeknadhandler.oppdaterDialog(sykepengesoeknad)


### PR DESCRIPTION
Fjern apiOnly-flagget for eksisterende dialoger når vi mottar oppdateringer. 
Dette gjøres for å sikre at GUI-brukere kan få se søknader som kommer inn på dialoger som ble opprettet med apiOnly=true, dette ble gjort fram til 12/6-26. 