### PR TITLE
stopp patching del1

### DIFF
--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -133,7 +133,7 @@ fun startServer() {
                 }
 
             launch(Dispatchers.Default + engangsjobbExceptionHandler) {
-                sykepengerDialogportenService.fixManglendeSykmeldinger()
+                // sykepengerDialogportenService.fixManglendeSykmeldinger()
             }
             routing {
                 naisRoutes(HelsesjekkService(database.db))


### PR DESCRIPTION
Når del1 er ferdig utført i produksjon, skal ikke jobben starte på nytt dersom pod restartes. 
Skal enables igjen når vi endrer koden til å kjøre del2.