### PR TITLE
Fjern api only toggle

### DIFF
--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -75,7 +75,6 @@ fun startServer() {
         SykepengerDialogportenService(
             dialogRepository = dialogRepository,
             dialogportenClient = sykePengerdialogportenClient,
-            unleashFeatureToggles = unleashFeatureToggles,
         )
     val fritakDialogportenService =
         FritakDialogportenService(

--- a/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
+++ b/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
@@ -23,23 +23,20 @@ import no.nav.helsearbeidsgiver.kafka.Inntektsmeldingsforespoersel
 import no.nav.helsearbeidsgiver.kafka.Sykepengesoeknad
 import no.nav.helsearbeidsgiver.kafka.Sykmelding
 import no.nav.helsearbeidsgiver.kafka.UtgaattInntektsmeldingForespoersel
-import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class SykepengerDialogportenService(
     private val dialogRepository: DialogRepository,
     private val dialogportenClient: DialogportenClient,
-    unleashFeatureToggles: UnleashFeatureToggles,
 ) {
     private val logger = logger()
-    private val sykmeldingHandler = SykmeldingHandler(dialogRepository, dialogportenClient, unleashFeatureToggles)
+    private val sykmeldingHandler = SykmeldingHandler(dialogRepository, dialogportenClient)
     private val sykepengesoeknadHandler = SykepengesoeknadHandler(dialogRepository, dialogportenClient)
     private val forespoerselHandler = ForespoerselHandler(dialogRepository, dialogportenClient)
     private val inntektsmeldingHandler = InntektsmeldingHandler(dialogRepository, dialogportenClient)
@@ -163,7 +160,8 @@ class SykepengerDialogportenService(
         transmissions
             .filter { it.dokumentType == LpsApiExtendedType.SYKEPENGESOEKNAD.toString() }
             .forEach { transmission ->
-                val sykepengersoknadTransmission = sykepengesoknadTransmission(transmission.dokumentId, isSilentUpdate = true)
+                val sykepengersoknadTransmission =
+                    sykepengesoknadTransmission(transmission.dokumentId, isSilentUpdate = true)
                 patchTransmission(
                     transmission = sykepengersoknadTransmission,
                     dialogId = dialog.dialogId,
@@ -188,7 +186,10 @@ class SykepengerDialogportenService(
             return true
         } catch (e: Exception) {
             logger.error("Klarte ikke å fikse transmission $transmissionId i dialog $dialogId")
-            sikkerLogger().error("Klarte ikke å fikse transmission tittel: ${transmission.tittel}, $transmissionId i dialog $dialogId", e)
+            sikkerLogger().error(
+                "Klarte ikke å fikse transmission tittel: ${transmission.tittel}, $transmissionId i dialog $dialogId",
+                e,
+            )
             return false
         }
     }

--- a/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
+++ b/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
@@ -109,7 +109,7 @@ class SykepengerDialogportenService(
                                         }.onFailure {
                                             sikkerLogger().error(
                                                 "Feil ved patching av dialog ${dialogDto.dialogId}",
-                                                it
+                                                it,
                                             )
                                             logger().error("Feil ved patching av dialog ${dialogDto.dialogId}")
                                             feilet.incrementAndGet()

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -13,7 +13,6 @@ import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.kafka.Sykmelding
 import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
 import no.nav.helsearbeidsgiver.kafka.lagDialogAdditionalInfo
-import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
 import java.util.UUID
@@ -21,7 +20,6 @@ import java.util.UUID
 class SykmeldingHandler(
     private val dialogRepository: DialogRepository,
     private val dialogportenClient: DialogportenClient,
-    private val unleashFeatureToggles: UnleashFeatureToggles,
 ) {
     private val logger = logger()
 
@@ -42,7 +40,7 @@ class SykmeldingHandler(
                             listOf(
                                 sykmeldingTransmission(sykmelding.sykmeldingId).toTransmission(),
                             ),
-                        isApiOnly = unleashFeatureToggles.skalOppretteDialogKunForApi(),
+                        isApiOnly = false,
                     )
 
                 dialogportenClient.createDialog(request)

--- a/src/main/kotlin/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/utils/UnleashFeatureToggles.kt
@@ -3,10 +3,8 @@ package no.nav.helsearbeidsgiver.utils
 import io.getunleash.DefaultUnleash
 import io.getunleash.FakeUnleash
 import io.getunleash.Unleash
-import io.getunleash.UnleashContext
 import io.getunleash.util.UnleashConfig
 import no.nav.helsearbeidsgiver.Env
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class UnleashFeatureToggles {
     private val defaultUnleash: Unleash =
@@ -30,11 +28,5 @@ class UnleashFeatureToggles {
         defaultUnleash.isEnabled(
             "opprett-dialoger",
             false,
-        )
-
-    fun skalOppretteDialogKunForApi() =
-        defaultUnleash.isEnabled(
-            "opprett-dialog-kun-for-api",
-            true,
         )
 }

--- a/src/main/kotlin/utils/UnleashFeatureToggles.kt
+++ b/src/main/kotlin/utils/UnleashFeatureToggles.kt
@@ -27,6 +27,6 @@ class UnleashFeatureToggles {
     fun skalOppretteDialoger(): Boolean =
         defaultUnleash.isEnabled(
             "opprett-dialoger",
-            false,
+            true,
         )
 }

--- a/src/test/kotlin/DialogportenServiceTest.kt
+++ b/src/test/kotlin/DialogportenServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.helsearbeidsgiver.database.DialogRepository
-import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import sykepengesoeknad
 import sykmelding
 

--- a/src/test/kotlin/DialogportenServiceTest.kt
+++ b/src/test/kotlin/DialogportenServiceTest.kt
@@ -19,10 +19,9 @@ class DialogportenServiceTest :
         }
         val dialogRepository = mockk<DialogRepository>(relaxed = true)
         val dialogportenClient = mockk<DialogportenClient>(relaxed = true)
-        val unleashFeatureToggles = mockk<UnleashFeatureToggles>(relaxed = true)
 
         test("opprettOgLagreDialog skal kalle sykmeldingHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient)
 
             service.opprettOgLagreDialog(sykmelding)
 
@@ -30,7 +29,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedSykepengesoeknad skal kalle sykepengesoeknadHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient)
 
             service.oppdaterDialogMedSykepengesoeknad(sykepengesoeknad)
 
@@ -38,7 +37,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmeldingsforespoersel skal kalle forespoerselHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient)
 
             service.oppdaterDialogMedInntektsmeldingsforespoersel(inntektsmeldingsforespoersel)
 
@@ -46,7 +45,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmelding skal kalle inntektsmeldingHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient)
 
             service.oppdaterDialogMedInntektsmelding(inntektsmelding_godkjent)
 
@@ -54,7 +53,7 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedUtgaattForespoersel skal kalle utgaattForespoerselHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles)
+            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient)
 
             service.oppdaterDialogMedUtgaattForespoersel(forespoersel_utgaatt)
 

--- a/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykmeldingHandlerTest.kt
@@ -15,7 +15,6 @@ import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.domene.CreateDialogRequest
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykmeldingHandler
 import no.nav.helsearbeidsgiver.kafka.getSykmeldingsPerioderString
-import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.tilNorskFormat
 import sykmelding
 import java.util.UUID
@@ -24,12 +23,10 @@ class SykmeldingHandlerTest :
     FunSpec({
         val dialogportenClientMock = mockk<DialogportenClient>()
         val dialogRepositoryMock = mockk<DialogRepository>()
-        val unleashFeatureTogglesMock = mockk<UnleashFeatureToggles>()
         val sykmeldingHandler =
             SykmeldingHandler(
                 dialogRepositoryMock,
                 dialogportenClientMock,
-                unleashFeatureTogglesMock,
             )
         beforeTest {
             clearAllMocks()
@@ -42,8 +39,6 @@ class SykmeldingHandlerTest :
             coEvery { dialogportenClientMock.createDialog(capture(requestSlot)) } returns dialogId
             every { dialogRepositoryMock.lagreDialog(any(), any()) } just Runs
             coEvery { dialogportenClientMock.setDialogStatus(any(), any()) } just Runs
-            every { unleashFeatureTogglesMock.skalOppretteDialogKunForApi() } returns
-                true
             sykmeldingHandler.opprettOgLagreDialog(sykmelding)
 
             val capturedRequest = requestSlot.captured
@@ -51,7 +46,7 @@ class SykmeldingHandlerTest :
             capturedRequest.externalReference shouldBe sykmelding.sykmeldingId.toString()
             capturedRequest.title shouldBe "Sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
             capturedRequest.summary shouldBe sykmelding.sykmeldingsperioder.getSykmeldingsPerioderString()
-            capturedRequest.isApiOnly shouldBe true
+            capturedRequest.isApiOnly shouldBe false
 
             verify(exactly = 1) {
                 dialogRepositoryMock.lagreDialog(

--- a/src/test/kotlin/local/AppLokal.kt
+++ b/src/test/kotlin/local/AppLokal.kt
@@ -62,7 +62,6 @@ fun startServer() {
         SykepengerDialogportenService(
             dialogRepository = dialogRepository,
             dialogportenClient = dialogportenClient,
-            unleashFeatureToggles = unleashFeatureToggles,
         )
     val fritakDialogportenService =
         FritakDialogportenService(


### PR DESCRIPTION
**Bakgrunn**
Det er på tide å rydde i gamle toggles.

**Løsning**
1. Fjern bruken av togglen `opprett-dialog-kun-for-api` og sett `isApiOnly` til `false` for nye dialoger.
2. Endre defaultverdien (som vil tas i bruk f.eks. dersom Unleash går ned) for togglen `opprett-dialoger` til `true`.