### PR TITLE
Opprett fager sak og beskjed for søknader

### DIFF
--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -71,7 +71,7 @@ fun startServer() {
         ArbeidsgiverNotifikasjonKlient(
             url = Env.Notifikasjon.apiUrl,
             getAccessToken = authClient.azureAdTokenGetter(Env.Notifikasjon.scope),
-            sendevindu = Sendevindu.NKS_AAPNINGSTID,
+            sendevindu = Sendevindu.LOEPENDE, // TODO bytt tilbake til nks_aapningstid
         )
 
     logger.info("Setter opp DialogRepository...")

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -87,6 +87,7 @@ fun startServer() {
             dialogportenClient = sykePengerdialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
             agNotifikasjonKlient = agNotifikasjonKlient,
+            dokumentkoblingRepository = dokumentkoblingRepository,
         )
     val fritakDialogportenService =
         FritakDialogportenService(

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -71,7 +71,7 @@ fun startServer() {
         ArbeidsgiverNotifikasjonKlient(
             url = Env.Notifikasjon.apiUrl,
             getAccessToken = authClient.azureAdTokenGetter(Env.Notifikasjon.scope),
-            sendevindu = Sendevindu.LOEPENDE, // TODO bytt tilbake til nks_aapningstid
+            sendevindu = Sendevindu.NKS_AAPNINGSTID,
         )
 
     logger.info("Setter opp DialogRepository...")

--- a/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
+++ b/src/main/kotlin/dialogporten/SykepengerDialogportenService.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjo
 import no.nav.helsearbeidsgiver.database.DialogEntity
 import no.nav.helsearbeidsgiver.database.DialogForPatch
 import no.nav.helsearbeidsgiver.database.DialogRepository
+import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.dialogporten.handlers.ForespoerselHandler
@@ -36,10 +37,18 @@ class SykepengerDialogportenService(
     private val dialogportenClient: DialogportenClient,
     unleashFeatureToggles: UnleashFeatureToggles,
     agNotifikasjonKlient: ArbeidsgiverNotifikasjonKlient,
+    dokumentkoblingRepository: DokumentkoblingRepository,
 ) {
     private val logger = logger()
     private val sykmeldingHandler = SykmeldingHandler(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
-    private val sykepengesoeknadHandler = SykepengesoeknadHandler(dialogRepository, dialogportenClient)
+    private val sykepengesoeknadHandler =
+        SykepengesoeknadHandler(
+            dialogRepository,
+            dialogportenClient,
+            unleashFeatureToggles,
+            agNotifikasjonKlient,
+            dokumentkoblingRepository,
+        )
     private val forespoerselHandler = ForespoerselHandler(dialogRepository, dialogportenClient)
     private val inntektsmeldingHandler = InntektsmeldingHandler(dialogRepository, dialogportenClient)
     private val utgaattForespoerselHandler = UtgaattForespoerselHandler(dialogRepository, dialogportenClient)

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -46,7 +46,8 @@ class SykepengesoeknadHandler(
 
         if (eksisterendeTransmission != null) {
             logger.info(
-                "Transmission for sykepengesøknad ${sykepengesoeknad.soeknadId} finnes allerede i dialog ${dialog.dialogId}, hopper over opprettelse.",
+                "Transmission for sykepengesøknad ${sykepengesoeknad.soeknadId} " +
+                    "finnes allerede i dialog ${dialog.dialogId}, hopper over opprettelse.",
             )
         } else {
             val transmissionId =

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -90,7 +90,8 @@ class SykepengesoeknadHandler(
         sykepengesoeknad: Sykepengesoeknad,
         sykmelding: dokumentkobling.Sykmelding,
     ) {
-        val sakTittel = "Søknad om sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
+        val sakTittel =
+            "Søknad om sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
 
         val lenke = "${Env.Nav.arbeidsgiverGuiBaseUrl}/dokument/sykepengesoeknad/${sykepengesoeknad.soeknadId}.pdf"
         val grupperingsid = sykepengesoeknad.soeknadId.toString()

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -136,9 +136,9 @@ private fun ArbeidsgiverNotifikasjonKlient.opprettNotifikasjoner(
                     grupperingsid = grupperingsid,
                     tjeneste = Tjeneste.SOEKNAD,
                     lenke = lenke,
-                    tekst = "Ny søknad om sykepenger for en av dine ansatte",
+                    tekst = "Ny søknad om sykepenger",
                     tidspunkt = null,
-                    varslingTittel = "Ny søknad om sykepenger",
+                    varslingTittel = "Ny søknad om sykepenger for en av dine ansatte",
                     varslingInnhold =
                         "<p>En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} " +
                             "har sendt inn en søknad om sykepenger.</p>" +

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -2,7 +2,12 @@ package no.nav.helsearbeidsgiver.dialogporten.handlers
 
 import kotlinx.coroutines.runBlocking
 import no.nav.helsearbeidsgiver.Env
+import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
+import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
+import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Tjeneste
+import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
 import no.nav.helsearbeidsgiver.database.DialogRepository
+import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.LpsApiExtendedType
 import no.nav.helsearbeidsgiver.dialogporten.SykepengesoknadTransmissionRequest
@@ -10,17 +15,23 @@ import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.createApiAttachment
 import no.nav.helsearbeidsgiver.dialogporten.domene.createGuiAttachment
 import no.nav.helsearbeidsgiver.kafka.Sykepengesoeknad
+import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.tilNorskFormat
 import java.util.UUID
+import kotlin.time.Duration.Companion.days
 
 class SykepengesoeknadHandler(
     private val dialogRepository: DialogRepository,
     private val dialogportenClient: DialogportenClient,
+    private val unleashFeatureToggles: UnleashFeatureToggles,
+    private val agNotifikasjonKlient: ArbeidsgiverNotifikasjonKlient,
+    private val dokumentkoblingRepository: DokumentkoblingRepository,
 ) {
     private val logger = logger()
 
     fun oppdaterDialog(sykepengesoeknad: Sykepengesoeknad) {
-        // TODO: Hvis ikke finnes - lage???
         val dialog =
             dialogRepository.finnDialogMedSykemeldingId(sykmeldingId = sykepengesoeknad.sykmeldingId)
                 ?: run {
@@ -31,27 +42,112 @@ class SykepengesoeknadHandler(
                     return
                 }
 
-        val transmissionId =
-            runBlocking {
-                dialogportenClient.removeApiOnly(dialog.dialogId)
-                dialogportenClient.addTransmission(
-                    dialogId = dialog.dialogId,
-                    transmissionRequest = sykepengesoknadTransmission(sykepengesoeknad.soeknadId),
+        val eksisterendeTransmission = dialog.transmissionByDokumentId(sykepengesoeknad.soeknadId)
+
+        if (eksisterendeTransmission != null) {
+            logger.info(
+                "Transmission for sykepengesøknad ${sykepengesoeknad.soeknadId} finnes allerede i dialog ${dialog.dialogId}, hopper over opprettelse.",
+            )
+        } else {
+            val transmissionId =
+                runBlocking {
+                    dialogportenClient.removeApiOnly(dialog.dialogId)
+                    dialogportenClient.addTransmission(
+                        dialogId = dialog.dialogId,
+                        transmissionRequest = sykepengesoknadTransmission(sykepengesoeknad.soeknadId),
+                    )
+                }
+
+            dialogRepository.oppdaterDialogMedTransmission(
+                sykmeldingId = sykepengesoeknad.sykmeldingId,
+                transmissionId = transmissionId,
+                dokumentId = sykepengesoeknad.soeknadId,
+                dokumentType = LpsApiExtendedType.SYKEPENGESOEKNAD.toString(),
+            )
+
+            logger.info(
+                "Oppdaterte dialog ${dialog.dialogId} for sykmelding ${sykepengesoeknad.sykmeldingId} " +
+                    "med sykepengesøknad ${sykepengesoeknad.soeknadId}. " +
+                    "Lagt til transmission $transmissionId.",
+            )
+        }
+
+        if (unleashFeatureToggles.skalOppretteNotifikasjoner()) {
+            val sykmeldingEntitet = dokumentkoblingRepository.hentSykmeldingEntitet(sykepengesoeknad.sykmeldingId)
+            if (sykmeldingEntitet == null) {
+                logger.warn(
+                    "Fant ikke sykmelding ${sykepengesoeknad.sykmeldingId} i databasen. " +
+                        "Kan ikke opprette notifikasjoner for sykepengesøknad ${sykepengesoeknad.soeknadId}.",
                 )
+            } else {
+                opprettNotifikasjoner(sykepengesoeknad, sykmeldingEntitet.data)
             }
+        }
+    }
 
-        dialogRepository.oppdaterDialogMedTransmission(
-            sykmeldingId = sykepengesoeknad.sykmeldingId,
-            transmissionId = transmissionId,
-            dokumentId = sykepengesoeknad.soeknadId,
-            dokumentType = LpsApiExtendedType.SYKEPENGESOEKNAD.toString(),
-        )
+    private fun opprettNotifikasjoner(
+        sykepengesoeknad: Sykepengesoeknad,
+        sykmelding: dokumentkobling.Sykmelding,
+    ) {
+        val sakTittel = "Søknad om sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
 
-        logger.info(
-            "Oppdaterte dialog ${dialog.dialogId} for sykmelding ${sykepengesoeknad.sykmeldingId} " +
-                "med sykepengesøknad ${sykepengesoeknad.soeknadId}. " +
-                "Lagt til transmission $transmissionId.",
-        )
+        val lenke = "${Env.Nav.arbeidsgiverGuiBaseUrl}/dokument/sykepengesoeknad/${sykepengesoeknad.soeknadId}.pdf"
+        val grupperingsid = sykepengesoeknad.soeknadId.toString()
+
+        try {
+            val sakId =
+                runBlocking {
+                    agNotifikasjonKlient.opprettNySak(
+                        virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
+                        grupperingsid = grupperingsid,
+                        tjeneste = Tjeneste.SOEKNAD,
+                        lenke = lenke,
+                        tittel = sakTittel,
+                        statusTekst = "Mottatt søknad om sykepenger",
+                        tilleggsinfo = null,
+                        initiellStatus = SaksStatus.MOTTATT,
+                        hardDeleteOm = 730.days,
+                    )
+                }
+            logger.info("Opprettet notifikasjon-sak $sakId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
+        } catch (e: SakEllerOppgaveDuplikatException) {
+            logger.warn("Duplikat sak for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
+        } catch (e: Exception) {
+            logger.error("Feil ved opprettelse av notifikasjon-sak for sykepengesøknad ${sykepengesoeknad.soeknadId}")
+            sikkerLogger().error("Feil ved opprettelse av notifikasjon-sak for sykepengesøknad ${sykepengesoeknad.soeknadId}", e)
+            throw e
+        }
+
+        try {
+            val beskjedId =
+                runBlocking {
+                    agNotifikasjonKlient.opprettNyBeskjed(
+                        virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
+                        eksternId = sykepengesoeknad.soeknadId.toString(),
+                        grupperingsid = grupperingsid,
+                        tjeneste = Tjeneste.SOEKNAD,
+                        lenke = lenke,
+                        tekst = "Ny søknad om sykepenger for en av dine ansatte",
+                        tidspunkt = null,
+                        varslingTittel = "Ny søknad om sykepenger",
+                        varslingInnhold =
+                            "<p>En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} har sendt inn en søknad om sykepenger.</p>" +
+                                "<p>Logg inn på Altinn eller Nav for å se søknaden.</p>" +
+                                "<p>Vennlig hilsen Nav.</p>",
+                        smsVarslingInnhold =
+                            "En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} har sendt inn en søknad om sykepenger. " +
+                                "Logg inn på Altinn eller Nav for å se søknaden. Vennlig hilsen Nav.",
+                        hardDeleteOm = 730.days,
+                    )
+                }
+            logger.info("Opprettet notifikasjon-beskjed $beskjedId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
+        } catch (e: SakEllerOppgaveDuplikatException) {
+            logger.warn("Duplikat beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
+        } catch (e: Exception) {
+            logger.error("Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}")
+            sikkerLogger().error("Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}", e)
+            throw e
+        }
     }
 }
 

--- a/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykepengesoeknadHandler.kt
@@ -81,75 +81,87 @@ class SykepengesoeknadHandler(
                         "Kan ikke opprette notifikasjoner for sykepengesøknad ${sykepengesoeknad.soeknadId}.",
                 )
             } else {
-                opprettNotifikasjoner(sykepengesoeknad, sykmeldingEntitet.data)
+                agNotifikasjonKlient.opprettNotifikasjoner(sykepengesoeknad, sykmeldingEntitet.data)
             }
         }
     }
+}
 
-    private fun opprettNotifikasjoner(
-        sykepengesoeknad: Sykepengesoeknad,
-        sykmelding: dokumentkobling.Sykmelding,
-    ) {
-        val sakTittel =
-            "Søknad om sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
+private fun ArbeidsgiverNotifikasjonKlient.opprettNotifikasjoner(
+    sykepengesoeknad: Sykepengesoeknad,
+    sykmelding: dokumentkobling.Sykmelding,
+) {
+    val logger = logger()
 
-        val lenke = "${Env.Nav.arbeidsgiverGuiBaseUrl}/dokument/sykepengesoeknad/${sykepengesoeknad.soeknadId}.pdf"
-        val grupperingsid = sykepengesoeknad.soeknadId.toString()
+    val sakTittel =
+        "Søknad om sykepenger for ${sykmelding.fulltNavn} (f. ${sykmelding.foedselsdato.tilNorskFormat()})"
 
-        try {
-            val sakId =
-                runBlocking {
-                    agNotifikasjonKlient.opprettNySak(
-                        virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
-                        grupperingsid = grupperingsid,
-                        tjeneste = Tjeneste.SOEKNAD,
-                        lenke = lenke,
-                        tittel = sakTittel,
-                        statusTekst = "Mottatt søknad om sykepenger",
-                        tilleggsinfo = null,
-                        initiellStatus = SaksStatus.MOTTATT,
-                        hardDeleteOm = 730.days,
-                    )
-                }
-            logger.info("Opprettet notifikasjon-sak $sakId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
-        } catch (e: SakEllerOppgaveDuplikatException) {
-            logger.warn("Duplikat sak for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
-        } catch (e: Exception) {
-            logger.error("Feil ved opprettelse av notifikasjon-sak for sykepengesøknad ${sykepengesoeknad.soeknadId}")
-            sikkerLogger().error("Feil ved opprettelse av notifikasjon-sak for sykepengesøknad ${sykepengesoeknad.soeknadId}", e)
-            throw e
-        }
+    val lenke = "${Env.Nav.arbeidsgiverGuiBaseUrl}/dokument/sykepengesoeknad/${sykepengesoeknad.soeknadId}.pdf"
+    val grupperingsid = sykepengesoeknad.soeknadId.toString()
 
-        try {
-            val beskjedId =
-                runBlocking {
-                    agNotifikasjonKlient.opprettNyBeskjed(
-                        virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
-                        eksternId = sykepengesoeknad.soeknadId.toString(),
-                        grupperingsid = grupperingsid,
-                        tjeneste = Tjeneste.SOEKNAD,
-                        lenke = lenke,
-                        tekst = "Ny søknad om sykepenger for en av dine ansatte",
-                        tidspunkt = null,
-                        varslingTittel = "Ny søknad om sykepenger",
-                        varslingInnhold =
-                            "<p>En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} har sendt inn en søknad om sykepenger.</p>" +
-                                "<p>Logg inn på Altinn eller Nav for å se søknaden.</p>" +
-                                "<p>Vennlig hilsen Nav.</p>",
-                        smsVarslingInnhold =
-                            "En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} har sendt inn en søknad om sykepenger. " +
-                                "Logg inn på Altinn eller Nav for å se søknaden. Vennlig hilsen Nav.",
-                        hardDeleteOm = 730.days,
-                    )
-                }
-            logger.info("Opprettet notifikasjon-beskjed $beskjedId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
-        } catch (e: SakEllerOppgaveDuplikatException) {
-            logger.warn("Duplikat beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
-        } catch (e: Exception) {
-            logger.error("Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}")
-            sikkerLogger().error("Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}", e)
-            throw e
-        }
+    try {
+        val sakId =
+            runBlocking {
+                this@opprettNotifikasjoner.opprettNySak(
+                    virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
+                    grupperingsid = grupperingsid,
+                    tjeneste = Tjeneste.SOEKNAD,
+                    lenke = lenke,
+                    tittel = sakTittel,
+                    statusTekst = "Mottatt søknad om sykepenger",
+                    tilleggsinfo = null,
+                    initiellStatus = SaksStatus.MOTTATT,
+                    hardDeleteOm = 730.days,
+                )
+            }
+        logger.info("Opprettet notifikasjon-sak $sakId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
+    } catch (e: SakEllerOppgaveDuplikatException) {
+        logger.warn("Duplikat sak for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
+    } catch (e: Exception) {
+        logger.error("Feil ved opprettelse av notifikasjon-sak for sykepengesøknad ${sykepengesoeknad.soeknadId}")
+        sikkerLogger().error(
+            "Feil ved opprettelse av notifikasjon-sak for sykepengesøknad " +
+                "${sykepengesoeknad.soeknadId}",
+            e,
+        )
+        throw e
+    }
+
+    try {
+        val beskjedId =
+            runBlocking {
+                this@opprettNotifikasjoner.opprettNyBeskjed(
+                    virksomhetsnummer = sykepengesoeknad.orgnr.verdi,
+                    eksternId = sykepengesoeknad.soeknadId.toString(),
+                    grupperingsid = grupperingsid,
+                    tjeneste = Tjeneste.SOEKNAD,
+                    lenke = lenke,
+                    tekst = "Ny søknad om sykepenger for en av dine ansatte",
+                    tidspunkt = null,
+                    varslingTittel = "Ny søknad om sykepenger",
+                    varslingInnhold =
+                        "<p>En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} " +
+                            "har sendt inn en søknad om sykepenger.</p>" +
+                            "<p>Logg inn på Altinn eller Nav for å se søknaden.</p>" +
+                            "<p>Vennlig hilsen Nav.</p>",
+                    smsVarslingInnhold =
+                        "En ansatt i underenhet med orgnr ${sykepengesoeknad.orgnr.verdi} " +
+                            "har sendt inn en søknad om sykepenger. " +
+                            "Logg inn på Altinn eller Nav for å se søknaden. Vennlig hilsen Nav.",
+                    hardDeleteOm = 730.days,
+                )
+            }
+        logger.info("Opprettet notifikasjon-beskjed $beskjedId for sykepengesøknad ${sykepengesoeknad.soeknadId}.")
+    } catch (e: SakEllerOppgaveDuplikatException) {
+        logger.warn("Duplikat beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}: ${e.eksisterendeId}")
+    } catch (e: Exception) {
+        logger.error("Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad ${sykepengesoeknad.soeknadId}")
+        sikkerLogger().error(
+            "Feil ved opprettelse av notifikasjon-beskjed for sykepengesøknad " +
+                "${sykepengesoeknad.soeknadId}",
+            e,
+        )
+        throw e
     }
 }
 

--- a/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
+++ b/src/main/kotlin/dialogporten/handlers/SykmeldingHandler.kt
@@ -108,7 +108,7 @@ class SykmeldingHandler(
                         grupperingsid = grupperingsid,
                         tjeneste = Tjeneste.SYKMELDING,
                         lenke = lenke,
-                        tekst = "Ny sykmelding for en av dine ansatte",
+                        tekst = "Ny sykmelding",
                         tidspunkt = null,
                         varslingTittel = "Ny sykmelding for en av dine ansatte",
                         varslingInnhold =

--- a/src/test/kotlin/DialogportenServiceTest.kt
+++ b/src/test/kotlin/DialogportenServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.verify
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.database.DialogForPatch
 import no.nav.helsearbeidsgiver.database.DialogRepository
+import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.database.TransmissionForPatch
 import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import sykepengesoeknad
@@ -26,6 +27,7 @@ class DialogportenServiceTest :
         val dialogportenClient = mockk<DialogportenClient>(relaxed = true)
         val unleashFeatureToggles = mockk<UnleashFeatureToggles>(relaxed = true)
         val agNotifikasjonKlient = mockk<ArbeidsgiverNotifikasjonKlient>(relaxed = true)
+        val dokumentkoblingRepository = mockk<DokumentkoblingRepository>(relaxed = true)
 
         test("patch") {
             // TODO: Temp: Denne testen kan slettes når vi har patchet ok!
@@ -54,7 +56,14 @@ class DialogportenServiceTest :
 
             coEvery { dialogRepository.hentDialogerOpprettetPaaDag(any()) } returns listOf(dialog1, dialog2)
 
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
             val start = System.currentTimeMillis()
             service.oppdaterTransmisjonerMedFeilUrl()
             val end = System.currentTimeMillis()
@@ -62,7 +71,14 @@ class DialogportenServiceTest :
             println("fix manglende sykmeldinger took $duration ms")
         }
         test("opprettOgLagreDialog skal kalle sykmeldingHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
 
             service.opprettOgLagreDialog(sykmelding)
 
@@ -70,7 +86,14 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedSykepengesoeknad skal kalle sykepengesoeknadHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
 
             service.oppdaterDialogMedSykepengesoeknad(sykepengesoeknad)
 
@@ -78,7 +101,14 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmeldingsforespoersel skal kalle forespoerselHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
 
             service.oppdaterDialogMedInntektsmeldingsforespoersel(inntektsmeldingsforespoersel)
 
@@ -86,7 +116,14 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedInntektsmelding skal kalle inntektsmeldingHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
 
             service.oppdaterDialogMedInntektsmelding(inntektsmelding_godkjent)
 
@@ -94,7 +131,14 @@ class DialogportenServiceTest :
         }
 
         test("oppdaterDialogMedUtgaattForespoersel skal kalle utgaattForespoerselHandler") {
-            val service = SykepengerDialogportenService(dialogRepository, dialogportenClient, unleashFeatureToggles, agNotifikasjonKlient)
+            val service =
+                SykepengerDialogportenService(
+                    dialogRepository,
+                    dialogportenClient,
+                    unleashFeatureToggles,
+                    agNotifikasjonKlient,
+                    dokumentkoblingRepository,
+                )
 
             service.oppdaterDialogMedUtgaattForespoersel(forespoersel_utgaatt)
 

--- a/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
+++ b/src/test/kotlin/dialogporten/handlers/SykepengesoeknadHandlerTest.kt
@@ -9,13 +9,19 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.database.DialogEntity
 import no.nav.helsearbeidsgiver.database.DialogRepository
+import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
+import no.nav.helsearbeidsgiver.database.SykmeldingEntity
+import no.nav.helsearbeidsgiver.database.TransmissionEntity
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.LpsApiExtendedType
 import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.handlers.SykepengesoeknadHandler
+import no.nav.helsearbeidsgiver.utils.UnleashFeatureToggles
 import sykepengesoeknad
+import java.time.LocalDate
 import java.util.UUID
 
 class SykepengesoeknadHandlerTest :
@@ -23,27 +29,36 @@ class SykepengesoeknadHandlerTest :
 
         val dialogportenClientMock = mockk<DialogportenClient>()
         val dialogRepositoryMock = mockk<DialogRepository>()
+        val unleashFeatureTogglesMock = mockk<UnleashFeatureToggles>()
+        val agNotifikasjonKlientMock = mockk<ArbeidsgiverNotifikasjonKlient>()
+        val dokumentkoblingRepositoryMock = mockk<DokumentkoblingRepository>()
         val sykepengeSoeknadhandler =
             SykepengesoeknadHandler(
                 dialogRepositoryMock,
                 dialogportenClientMock,
+                unleashFeatureTogglesMock,
+                agNotifikasjonKlientMock,
+                dokumentkoblingRepositoryMock,
             )
 
         beforeTest {
             clearAllMocks()
         }
+
         test("skal oppdatere dialog med sykepengesøknad") {
             val dialogId = UUID.randomUUID()
             val transmissionId = UUID.randomUUID()
             val dialogEntity =
                 mockk<DialogEntity> {
                     every { this@mockk.dialogId } returns dialogId
+                    every { transmissionByDokumentId(sykepengesoeknad.soeknadId) } returns null
                 }
 
             every { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) } returns dialogEntity
             coEvery { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) } returns transmissionId
             coEvery { dialogportenClientMock.removeApiOnly(any()) } just Runs
             every { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) } just Runs
+            every { unleashFeatureTogglesMock.skalOppretteNotifikasjoner() } returns false
 
             sykepengeSoeknadhandler.oppdaterDialog(sykepengesoeknad)
 
@@ -67,5 +82,109 @@ class SykepengesoeknadHandlerTest :
             verify(exactly = 1) { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) }
             coVerify(exactly = 0) { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) }
             verify(exactly = 0) { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) }
+        }
+
+        test("skal hoppe over transmission hvis den allerede finnes, men fortsatt opprette notifikasjoner") {
+            val dialogId = UUID.randomUUID()
+            val eksisterendeTransmission = mockk<TransmissionEntity>()
+            val sykmeldingEntitet =
+                mockk<SykmeldingEntity> {
+                    every { data } returns
+                        dokumentkobling.Sykmelding(
+                            sykmeldingId = sykepengesoeknad.sykmeldingId,
+                            orgnr = sykepengesoeknad.orgnr,
+                            foedselsdato = LocalDate.of(1990, 1, 1),
+                            fulltNavn = "OLA NORDMANN",
+                            sykmeldingsperioder = emptyList(),
+                        )
+                }
+            val dialogEntity =
+                mockk<DialogEntity> {
+                    every { this@mockk.dialogId } returns dialogId
+                    every { transmissionByDokumentId(sykepengesoeknad.soeknadId) } returns eksisterendeTransmission
+                }
+
+            every { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) } returns dialogEntity
+            every { unleashFeatureTogglesMock.skalOppretteNotifikasjoner() } returns true
+            every { dokumentkoblingRepositoryMock.hentSykmeldingEntitet(sykepengesoeknad.sykmeldingId) } returns sykmeldingEntitet
+            coEvery { agNotifikasjonKlientMock.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                UUID.randomUUID().toString()
+            coEvery {
+                agNotifikasjonKlientMock.opprettNyBeskjed(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns UUID.randomUUID().toString()
+
+            sykepengeSoeknadhandler.oppdaterDialog(sykepengesoeknad)
+
+            coVerify(exactly = 0) { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) }
+            verify(exactly = 0) { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) { agNotifikasjonKlientMock.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) {
+                agNotifikasjonKlientMock.opprettNyBeskjed(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
+        }
+
+        test("skal opprette notifikasjoner etter oppdatering av dialog") {
+            val dialogId = UUID.randomUUID()
+            val transmissionId = UUID.randomUUID()
+            val sykmeldingEntitet =
+                mockk<SykmeldingEntity> {
+                    every { data } returns
+                        dokumentkobling.Sykmelding(
+                            sykmeldingId = sykepengesoeknad.sykmeldingId,
+                            orgnr = sykepengesoeknad.orgnr,
+                            foedselsdato = LocalDate.of(1990, 1, 1),
+                            fulltNavn = "OLA NORDMANN",
+                            sykmeldingsperioder = emptyList(),
+                        )
+                }
+            val dialogEntity =
+                mockk<DialogEntity> {
+                    every { this@mockk.dialogId } returns dialogId
+                    every { transmissionByDokumentId(sykepengesoeknad.soeknadId) } returns null
+                }
+
+            every { dialogRepositoryMock.finnDialogMedSykemeldingId(sykepengesoeknad.sykmeldingId) } returns dialogEntity
+            coEvery { dialogportenClientMock.addTransmission(any(), any<TransmissionRequest>()) } returns transmissionId
+            coEvery { dialogportenClientMock.removeApiOnly(any()) } just Runs
+            every { dialogRepositoryMock.oppdaterDialogMedTransmission(any(), any(), any(), any(), any()) } just Runs
+            every { unleashFeatureTogglesMock.skalOppretteNotifikasjoner() } returns true
+            every { dokumentkoblingRepositoryMock.hentSykmeldingEntitet(sykepengesoeknad.sykmeldingId) } returns sykmeldingEntitet
+            coEvery { agNotifikasjonKlientMock.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+                UUID.randomUUID().toString()
+            coEvery {
+                agNotifikasjonKlientMock.opprettNyBeskjed(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } returns UUID.randomUUID().toString()
+
+            sykepengeSoeknadhandler.oppdaterDialog(sykepengesoeknad)
+
+            coVerify(exactly = 1) { dialogportenClientMock.addTransmission(dialogId, any<TransmissionRequest>()) }
+            coVerify(exactly = 1) { agNotifikasjonKlientMock.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+            coVerify(exactly = 1) {
+                agNotifikasjonKlientMock.opprettNyBeskjed(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            }
         }
     })

--- a/src/test/kotlin/local/AppLokal.kt
+++ b/src/test/kotlin/local/AppLokal.kt
@@ -65,6 +65,7 @@ fun startServer() {
             dialogportenClient = dialogportenClient,
             unleashFeatureToggles = unleashFeatureToggles,
             agNotifikasjonKlient = mockk<ArbeidsgiverNotifikasjonKlient>(relaxed = true),
+            dokumentkoblingRepository = dokumentkoblingRepository,
         )
     val fritakDialogportenService =
         FritakDialogportenService(


### PR DESCRIPTION
Oppretter fager sak og beskjed for søknader om sykepenger.
Implementerer det på samme måte som #91 .
Må hente navn og fødselsdato fra json i sykmeldingtabellen.