### PR TITLE
Legg til transmission lest route

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -56,6 +56,10 @@ spec:
           namespace: fager
         - application: logging
           namespace: nais-system
+    inbound:
+      rules:
+        - application: hag-dokument-proxy
+          namespace: helsearbeidsgiver
   maskinporten:
     enabled: true
     scopes:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -56,6 +56,10 @@ spec:
           namespace: fager
         - application: logging
           namespace: nais-system
+    inbound:
+      rules:
+        - application: hag-dokument-proxy
+          namespace: helsearbeidsgiver
   maskinporten:
     enabled: true
     scopes:

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,7 @@ kotlinterVersion=5.2.0
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
 arbeidsgiverNotifikasjonKlientVersion=4.3.1
-#TODO: Bytt til release når PR for 2.8.0 er merget
-dialogportenClientVersion=2.8.0-SNAPSHOT
+dialogportenClientVersion=2.8.0
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,8 @@ kotlinterVersion=5.2.0
 # Interne avhengigheter
 bakgrunnsjobbVersion=1.0.7
 arbeidsgiverNotifikasjonKlientVersion=4.3.1
-dialogportenClientVersion=2.7.1
+#TODO: Bytt til release når PR for 2.8.0 er merget
+dialogportenClientVersion=2.8.0-SNAPSHOT
 utilsVersion=0.9.0
 
 # Eksterne avhengigheter

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -21,6 +21,7 @@ import no.nav.helsearbeidsgiver.database.DokumentkoblingRepository
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.dialogporten.FritakDialogportenService
 import no.nav.helsearbeidsgiver.dialogporten.SykepengerDialogportenService
+import no.nav.helsearbeidsgiver.dialogporten.activity.activityRoutes
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytForespoerselJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytInntektsmeldingJobb
 import no.nav.helsearbeidsgiver.dokumentkobling.AvbrytSykepengeSoeknadJobb
@@ -146,6 +147,7 @@ fun startServer() {
             routing {
                 naisRoutes(HelsesjekkService(database.db))
                 metrikkRoutes()
+                activityRoutes(sykePengerdialogportenClient)
             }
             configureKafkaConsumer(unleashFeatureToggles, dokumentKoblingService, fritakDialogportenService)
             startRecurringJobs(jobber)

--- a/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
+++ b/src/main/kotlin/dialogporten/SykepengeTransmissionRequest.kt
@@ -29,6 +29,7 @@ class SykmeldingTransmissionRequest(
     override val dokumentId = sykmeldingId
     override val tittel = "Sykmelding"
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = Transmission.TransmissionType.Information
     override val relatedTransmissionId = null
 }
@@ -42,6 +43,7 @@ class SykepengesoknadTransmissionRequest(
     override val dokumentId = soeknadId
     override val tittel = "Søknad om sykepenger"
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = Transmission.TransmissionType.Information
     override val relatedTransmissionId = null
 }
@@ -55,6 +57,7 @@ class ForespoerselTransmissionRequest(
     override val dokumentId = forespoerselId
     override val tittel = "Forespørsel om inntektsmelding"
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = Transmission.TransmissionType.Request
 }
 
@@ -67,6 +70,7 @@ class UtgaattForespoerselTransmissionRequest(
     override val dokumentId = forespoerselId
     override val tittel = "Forespørsel er utgått"
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = Transmission.TransmissionType.Information
 }
 
@@ -97,6 +101,7 @@ class InntektsmeldingTransmissionRequest(
     override val dokumentId = inntektsmelding.innsendingId
     override val tittel = inntektsmelding.status.toTittel()
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = inntektsmelding.status.toTransmissionType()
 }
 
@@ -108,6 +113,7 @@ class FritakKravTransmissionRequest(
     override val extendedType = finnTypeForFritakKrav(kravMelding).toString()
     override val tittel = kravMelding.toTittel()
     override val sammendrag = null
+    override val contentReferenceFceUrl = null
     override val type = Transmission.TransmissionType.Information
     override val attachments =
         listOf(

--- a/src/main/kotlin/dialogporten/activity/ActivityRouting.kt
+++ b/src/main/kotlin/dialogporten/activity/ActivityRouting.kt
@@ -1,0 +1,26 @@
+package no.nav.helsearbeidsgiver.dialogporten.activity
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
+import no.nav.helsearbeidsgiver.utils.log.logger
+import java.util.UUID
+
+fun Route.activityRoutes(dialogportenClient: DialogportenClient) {
+    get("sett-transmission-lest") {
+        val dialogId = call.request.queryParameters["dialogId"].toUuidorNull()
+        val transmissionId = call.request.queryParameters["transmissionId"].toUuidorNull()
+
+        if (dialogId == null || transmissionId == null) {
+            return@get call.respond(HttpStatusCode.BadRequest)
+        }
+
+        logger().info("Setter transmission $transmissionId til lest for dialog $dialogId")
+        dialogportenClient.markTransmissionOpened(dialogId, transmissionId)
+        call.respond(HttpStatusCode.OK)
+    }
+}
+
+fun String?.toUuidorNull() = this?.let { runCatching { UUID.fromString(it) }.getOrNull() }

--- a/src/main/kotlin/dialogporten/activity/ActivityRouting.kt
+++ b/src/main/kotlin/dialogporten/activity/ActivityRouting.kt
@@ -4,20 +4,23 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.put
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import no.nav.helsearbeidsgiver.utils.log.logger
 import java.util.UUID
 
 fun Route.activityRoutes(dialogportenClient: DialogportenClient) {
-    get("sett-transmission-lest") {
+    put("transmission-lest") {
         val dialogId = call.request.queryParameters["dialogId"].toUuidorNull()
         val transmissionId = call.request.queryParameters["transmissionId"].toUuidorNull()
 
         if (dialogId == null || transmissionId == null) {
-            return@get call.respond(HttpStatusCode.BadRequest)
+            return@put call.respond(HttpStatusCode.BadRequest)
         }
 
         logger().info("Setter transmission $transmissionId til lest for dialog $dialogId")
+
+        // dialogporten validerer at transmissionId er i dialogId
         dialogportenClient.markTransmissionOpened(dialogId, transmissionId)
         call.respond(HttpStatusCode.OK)
     }

--- a/src/test/kotlin/dialogporten/activity/ActivityRoutingTest.kt
+++ b/src/test/kotlin/dialogporten/activity/ActivityRoutingTest.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.dialogporten.activity
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.get
+import io.ktor.client.request.put
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.TestApplication
@@ -12,7 +13,7 @@ import io.mockk.mockk
 import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
 import java.util.UUID
 
-const val LEST_PATH = "/sett-transmission-lest"
+const val LEST_PATH = "/transmission-lest"
 val dialogId: UUID = UUID.randomUUID()
 val transmissionId: UUID = UUID.randomUUID()
 
@@ -21,7 +22,7 @@ class ActivityRoutingTest :
 
         test("skal kalle dialogportenClient.markTransmissionOpened med gitte dialogId og transmissionId") {
             val response =
-                testApplication.client.get(
+                testApplication.client.put(
                     "$LEST_PATH?dialogId=$dialogId&transmissionId=$transmissionId",
                 )
 
@@ -31,7 +32,7 @@ class ActivityRoutingTest :
 
         test("skal returnere BadRequest når dialogId ikke er en gyldig UUID") {
             val response =
-                testApplication.client.get(
+                testApplication.client.put(
                     "$LEST_PATH?dialogId=ikke-en-uuid&transmissionId=$transmissionId",
                 )
 
@@ -41,7 +42,7 @@ class ActivityRoutingTest :
 
         test("skal returnere BadRequest når transmissionId ikke er en gyldig UUID") {
             val response =
-                testApplication.client.get(
+                testApplication.client.put(
                     "$LEST_PATH?dialogId=$dialogId&transmissionId=ikke-en-uuid",
                 )
 

--- a/src/test/kotlin/dialogporten/activity/ActivityRoutingTest.kt
+++ b/src/test/kotlin/dialogporten/activity/ActivityRoutingTest.kt
@@ -1,0 +1,76 @@
+package no.nav.helsearbeidsgiver.dialogporten.activity
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.TestApplication
+import io.mockk.clearMocks
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.helsearbeidsgiver.dialogporten.DialogportenClient
+import java.util.UUID
+
+const val LEST_PATH = "/sett-transmission-lest"
+val dialogId: UUID = UUID.randomUUID()
+val transmissionId: UUID = UUID.randomUUID()
+
+class ActivityRoutingTest :
+    FunSpecWithActivityRoutesTestApplication({ testApplication, dialogportenClient ->
+
+        test("skal kalle dialogportenClient.markTransmissionOpened med gitte dialogId og transmissionId") {
+            val response =
+                testApplication.client.get(
+                    "$LEST_PATH?dialogId=$dialogId&transmissionId=$transmissionId",
+                )
+
+            response.status shouldBe HttpStatusCode.OK
+            coVerify(exactly = 1) { dialogportenClient.markTransmissionOpened(dialogId, transmissionId) }
+        }
+
+        test("skal returnere BadRequest når dialogId ikke er en gyldig UUID") {
+            val response =
+                testApplication.client.get(
+                    "$LEST_PATH?dialogId=ikke-en-uuid&transmissionId=$transmissionId",
+                )
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            coVerify(exactly = 0) { dialogportenClient.markTransmissionOpened(any(), any()) }
+        }
+
+        test("skal returnere BadRequest når transmissionId ikke er en gyldig UUID") {
+            val response =
+                testApplication.client.get(
+                    "$LEST_PATH?dialogId=$dialogId&transmissionId=ikke-en-uuid",
+                )
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            coVerify(exactly = 0) { dialogportenClient.markTransmissionOpened(any(), any()) }
+        }
+    })
+
+abstract class FunSpecWithActivityRoutesTestApplication(
+    body: FunSpec.(TestApplication, DialogportenClient) -> Unit,
+) : FunSpec({
+        val dialogportenClient = mockk<DialogportenClient>(relaxed = true)
+
+        beforeTest {
+            clearMocks(dialogportenClient)
+        }
+
+        val testApplication =
+            TestApplication {
+                application {
+                    routing {
+                        activityRoutes(dialogportenClient)
+                    }
+                }
+            }
+
+        afterSpec {
+            testApplication.stop()
+        }
+
+        body(testApplication, dialogportenClient)
+    })


### PR DESCRIPTION
**Problem:**
Vår hag-dokument-proxy app skal sette transmission til lest.
Dialog appen er en backend app som ikke har struktur/støtte for parsing av frontend tokens.

**Løsning:**
Dialog appen har all eksisterende struktur og autentisering for å kjøre kall mot dialogporten.

Proxy appen leser tokenet og verifiserer at requesten er gyldig (ingen verifisering nødvendig i dialog appen)
Proxy appen gjør et internt service discovery kall til dialog appen (krever inbound rule)
Dialog appen setter transmission til lest via dialogporten client `markTransmissionOpened()`

**Notat:**
Bytt dialogporten client til non-SNAPSHOT versjon for 2.8.0

Ny dialogporten client versjon krever FCE url i transmission request (bruker bare null)

Er det greit at dette endepunktet bruker ressurs `urn:altinn:resource:nav_sykepenger_dialog` for alle kall?


**Sekvens diagram:**
<img width="460" alt="image (14)" src="https://github.com/user-attachments/assets/9dfef582-5aa5-468d-bc2b-2c61d161660f" />

